### PR TITLE
Fix non-existing install. Fixes #12.

### DIFF
--- a/info_terminal/approach_person_of_interest/setup.py
+++ b/info_terminal/approach_person_of_interest/setup.py
@@ -5,7 +5,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml
 setup_args = generate_distutils_setup(
-    packages=['approach_person_of_interest'],
+    packages=[],
     package_dir={'': 'src'})
 
 setup(**setup_args)


### PR DESCRIPTION
This "fix" just stops catkin trying to install a non-existing  python package from the approach_person package. Real install targets still need to be created...
