### PR TITLE
Walking group preemption and other updates

### DIFF
--- a/aaf_walking_group/conf/waypoint_sounds.yaml
+++ b/aaf_walking_group/conf/waypoint_sounds.yaml
@@ -1,0 +1,1 @@
+waypoint_sounds: '{"Lift1": "02 - Ghosts n Stuff.mp3", "WayPoint7": "02 - Ghosts n Stuff.mp3", "Cafeteria": "02 - Ghosts n Stuff.mp3", "WayPoint8": "02 - Ghosts n Stuff.mp3"}'

--- a/aaf_walking_group/launch/walking_group.launch
+++ b/aaf_walking_group/launch/walking_group.launch
@@ -4,7 +4,8 @@
   <arg name="collection_name" default="aaf_walking_group"/>
   <arg name="music_folder" default="$(find music_player)/media"/>
   <arg name="waypoint_sounds_folder" default="$(find aaf_waypoint_sounds)/media"/>
-  <arg name="waypoint_sounds" default='{"Lift1": "fringilla-coelebs.mp3", "WayPoint7": "larus-ridibundus.mp3", "Cafeteria": "melanitta-fusca.mp3", "WayPoint8": "turdus-merula.mp3"}'/>
+  <arg name="waypoint_sounds_file" default="$(find aaf_walking_group)/conf/waypoint_sounds.yaml" />
+  <arg name="music_set" default="aaf_walking_group"/>
 
   <node pkg="aaf_walking_group" type="wait_for_participant.py" name="wait_for_participant" output="screen"/>
   <node pkg="aaf_walking_group" type="guiding_action.py" name="guiding_server" output="screen"/>
@@ -20,7 +21,8 @@
 
   <include file="$(find aaf_waypoint_sounds)/launch/waypoint_sounds.launch">
     <arg name="audio_folder" value="$(arg waypoint_sounds_folder)"/>
-    <arg name="waypoint_sounds" value="$(arg waypoint_sounds)"/>
+    <arg name="music_set" value="$(arg music_set)"/>
+    <arg name="waypoint_sounds_file" value="$(arg waypoint_sounds_file)"/>
   </include>
   <node pkg="music_player" type="music_player_server.py" name="music_player_server">
     <param name="folder" type="string" value="$(arg music_folder)"/>

--- a/aaf_walking_group/scripts/aaf_walking_group_state_machine.py
+++ b/aaf_walking_group/scripts/aaf_walking_group_state_machine.py
@@ -19,12 +19,14 @@ import pprint
 
 class WalkingGroupStateMachine(object):
     def __init__(self, name):
+        rospy.loginfo("Creating " + name + " server...")
         self._as = actionlib.SimpleActionServer(
             name,
             StateMachineAction,
             self.execute,
             auto_start=False
         )
+        self._as.register_preempt_callback(self.preempt_callback)
 
         nav_client = actionlib.SimpleActionClient("guiding", GuidingAction)
         nav_client.wait_for_server()
@@ -43,7 +45,9 @@ class WalkingGroupStateMachine(object):
         # Setting http root
         http_root = roslib.packages.get_pkg_dir('aaf_walking_group') + '/www'
         strands_webserver.client_utils.set_http_root(http_root)
+        rospy.loginfo(" ... starting " + name)
         self._as.start()
+        rospy.loginfo(" ... started " + name)
 
 
     def execute(self, goal):
@@ -51,22 +55,23 @@ class WalkingGroupStateMachine(object):
         self.waypointset = self.loadConfig(self.waypointset_name, collection_name=self.waypointset_collection, meta_name=self.waypointset_meta)
         pprint.pprint(self.waypointset)
         # Create a SMACH state machine
-        sm = smach.StateMachine(outcomes=['succeeded', 'aborted', 'preempted'])
-        sm.userdata.current_waypoint = goal.start_waypoint
+        self.sm = smach.StateMachine(outcomes=['succeeded', 'aborted', 'preempted'])
+        self.sm.userdata.current_waypoint = goal.start_waypoint
         sis = smach_ros.IntrospectionServer(
             'walking_group_state_machine',
-            sm,
+            self.sm,
             '/walking_group_machine'
         )
         sis.start()
         # Open the container
-        with sm:
+        with self.sm:
             # Add states to the container
             smach.StateMachine.add(
                 'ENTERTAIN',
                 Entertain(self.display_no),
                 transitions={
-                    'key_card': 'GUIDE_INTERFACE'
+                    'key_card': 'GUIDE_INTERFACE',
+                    'killall': 'preempted'
                 },
                 remapping={'current_waypoint' : 'current_waypoint'}
             )
@@ -86,16 +91,21 @@ class WalkingGroupStateMachine(object):
                 transitions={
                     'reached_point': 'ENTERTAIN',
                     'reached_final_point': 'succeeded',
-                    'key_card': 'GUIDE_INTERFACE'
+                    'key_card': 'GUIDE_INTERFACE',
+                    'killall': 'preempted'
                 },
                 remapping={'waypoint' : 'waypoint'}
             )
 
         # Execute SMACH plan
-        sm.execute()
+        self.sm.execute()
 
         sis.stop()
         self._as.set_succeeded()
+
+    def preempt_callback(self):
+        rospy.logwarn("Walking group preempt requested")
+        self.sm.request_preempt()
 
     def loadConfig(self, dataset_name, collection_name="aaf_walking_group", meta_name="waypoint_set"):
         msg_store = MessageStoreProxy(collection=collection_name)

--- a/aaf_walking_group/scripts/guiding_action.py
+++ b/aaf_walking_group/scripts/guiding_action.py
@@ -15,57 +15,68 @@ from nav_msgs.msg import Path
 
 class GuidingServer():
 
-    def __init__(self):
+    def __init__(self, name):
+        rospy.loginfo("Creating "+name+" server")
         self.server = actionlib.SimpleActionServer(
-            'guiding',
+            '/guiding',
             GuidingAction,
             self.execute,
             False
         )
-        self.server.start()
+        self.server.register_preempt_callback(self.preempt_callback)
+
+        rospy.loginfo("Creating topo nav client...")
         self.client = actionlib.SimpleActionClient(
-            'topological_navigation',
+            '/topological_navigation',
             topological_navigation.msg.GotoNodeAction
         )
         self.client.wait_for_server()
+        rospy.loginfo(" ... done ")
+        rospy.loginfo("Creating wait client...")
         self.empty_client = actionlib.SimpleActionClient(
-            'wait_for_participant',
+            '/wait_for_participant',
             EmptyAction
         )
         self.empty_client.wait_for_server()
+        rospy.loginfo(" ... done ")
+        rospy.loginfo("Creating interface client...")
+        self.client_walking_interface = actionlib.SimpleActionClient(
+            '/walking_interface_server',
+            GuidingAction
+        )
+        self.client_walking_interface.wait_for_server()
+        rospy.loginfo(" ... done ")
         self.card_subscriber = rospy.Subscriber(
             "/socialCardReader/QSR_generator",
             String,
             self.card_callback
         )
         self.odom_subscriber = rospy.Subscriber(
-            "odom",
+            "/odom",
             Odometry,
             self.odom_callback,
             queue_size=1
         )
-        
+
         self.path_subscriber = rospy.Subscriber(
             "/move_base/DWAPlannerROS/local_plan",
             Path,
             self.path_callback,
             queue_size = 1
         )
-        
+
         self.last_location = Odometry()
         self.pause = 0
-        self.begin = 1
+        self.begin = 0
         self.counter = 0
         self.last_direction = ""
-
-        self.client_walking_interface = actionlib.SimpleActionClient(
-            'walking_interface_server',
-            GuidingAction
-        )
-        self._client.wait_for_server()
+        rospy.loginfo(" ... starting "+name)
+        self.server.start()
+        rospy.loginfo(" ... started "+name)
 
     def execute(self, goal):
-        self.begin = 1
+        self.begin = 0
+        self.pause = 0
         navgoal = topological_navigation.msg.GotoNodeGoal()
         navgoal.target = goal.waypoint
         self.client.send_goal(navgoal)
@@ -75,11 +86,26 @@ class GuidingServer():
         print ps
         self.server.set_succeeded()
 
+    def preempt_callback(self):
+        rospy.logwarn("Guiding action preempt requested")
+        self.client.cancel_all_goals()
+        self.empty_client.cancel_all_goals()
+        while not rospy.is_shutdown():
+            try:
+                pause_service = rospy.ServiceProxy(
+                    '/monitored_navigation/pause_nav',
+                    PauseResumeNav
+                )
+                pause_service(0)
+                break
+            except rospy.ServiceException, e:
+                print "Service call failed: %s" % e
+
     def _on_node_shutdown(self):
         self.client.cancel_all_goals()
 
     def card_callback(self, data):
-        if self.pause == 1:
+        if self.pause == 1 and self.server.is_active():
             # call action server
             if data.data == 'near':
                 self.odom_subscriber = None
@@ -98,8 +124,8 @@ class GuidingServer():
                                                         self.odom_callback)
 
     def odom_callback(self, data):
-        if self.begin == 0:
-            if self.counter == 10:
+        if self.begin == 0 and self.server.is_active():
+            if self.counter >= 10:
                 x = data.pose.pose.position.x - \
                     self.last_location.pose.pose.position.x
                 y = data.pose.pose.position.y - \
@@ -129,14 +155,14 @@ class GuidingServer():
             self.begin = 0
 
         self.counter += 1
-        
-    def path_callback(self, path): 
+
+    def path_callback(self, path):
         if self.server.is_active() and self.pause == 0:
             yDiff = path.poses[-1].pose.position.y - path.poses[0].pose.position.y
             xDiff = path.poses[-1].pose.position.x - path.poses[0].pose.position.x
-            
+
             angle = math.degrees(math.atan2(yDiff,xDiff))
-            
+
             if angle > -90 and angle < 85:
                 if not self.last_direction == "right":
                     direction = 'right'
@@ -158,9 +184,9 @@ class GuidingServer():
                     walking_interface_goal.waypoint = direction
                     self.client_walking_interface.send_goal(walking_interface_goal)
                     self.last_direction = "left"
-        
+
 
 if __name__ == '__main__':
     rospy.init_node('guiding_server')
-    server = GuidingServer()
+    server = GuidingServer(rospy.get_name())
     rospy.spin()

--- a/aaf_walking_group/scripts/positionOfCard.py
+++ b/aaf_walking_group/scripts/positionOfCard.py
@@ -16,17 +16,17 @@ class generate_QSR:
     def __init__(self):
         '''Initialize ros publisher, ros subscriber'''
         # topic where we publish
-        self.qsr_pub = rospy.Publisher("/socialCardReader/QSR_generator", String)
+        self.qsr_pub = rospy.Publisher("/socialCardReader/QSR_generator", String, queue_size=10)
 
         # subscribed Topic
         self.Subscriber = rospy.Subscriber("/socialCardReader/cardposition", PoseStamped, self.callback,  queue_size = 1)
-        
+
         if VERBOSE :
             print "subscribed to /socialCardReader/cardposition"
 
 
     def callback(self, position):
- 
+
         if VERBOSE :
             rospy.loginfo("Card position (x,y,z): [ %f, %f, %f ]"%(position.pose.position.x, position.pose.position.y, position.pose.position.z))
 
@@ -36,10 +36,10 @@ class generate_QSR:
 
             if VERBOSE :
               rospy.loginfo("the card is %s" %result)
-        
+
         # Publish qsr
         self.qsr_pub.publish(result)
-        
+
 def main(args):
 
     '''Initializes and cleanup ros node'''

--- a/aaf_walking_group/scripts/wait_for_participant.py
+++ b/aaf_walking_group/scripts/wait_for_participant.py
@@ -32,7 +32,10 @@ class WaitForParticipant(object):
         while not self.pressed and not rospy.is_shutdown() and not self._as.is_preempt_requested():
             pass
         print "Leave"
-        self._as.set_succeeded()
+        if not self._as.is_preempt_requested():
+            self._as.set_succeeded()
+        else:
+            self._as.set_preempted()
 
     def button(self, req):
         print "Pressed"

--- a/aaf_walking_group/scripts/wait_for_participant.py
+++ b/aaf_walking_group/scripts/wait_for_participant.py
@@ -14,19 +14,22 @@ class WaitForParticipant(object):
         self.display_no = rospy.get_param("~display_no", 0)
         self.pressed = False
         rospy.Service(name+'/button', Empty, self.button)
+        rospy.loginfo("Creating " + name + " server...")
         self._as = actionlib.SimpleActionServer(
             name,
             EmptyAction,
             self.execute,
             auto_start=False
         )
+        rospy.loginfo(" ... starting " + name)
         self._as.start()
+        rospy.loginfo(" ... started " + name)
 
     def execute(self, goal):
         print "Called"
         self.pressed = False
         strands_webserver.client_utils.display_relative_page(self.display_no, "continue_page.html")
-        while not self.pressed and not rospy.is_shutdown():
+        while not self.pressed and not rospy.is_shutdown() and not self._as.is_preempt_requested():
             pass
         print "Leave"
         self._as.set_succeeded()

--- a/aaf_walking_group/src/aaf_walking_group/entertain.py
+++ b/aaf_walking_group/src/aaf_walking_group/entertain.py
@@ -27,6 +27,8 @@ class Entertain(smach.State):
         while not self.card and not rospy.is_shutdown() and not self.preempt_requested():
             pass
         if self.preempt_requested():
+            self.sub.unregister()
+            self.sub = None
             return 'killall'
         return 'key_card'
 

--- a/aaf_walking_group/src/aaf_walking_group/entertain.py
+++ b/aaf_walking_group/src/aaf_walking_group/entertain.py
@@ -10,7 +10,7 @@ class Entertain(smach.State):
     def __init__(self, display_no):
         smach.State.__init__(
             self,
-            outcomes=['key_card'],
+            outcomes=['key_card', 'killall'],
             input_keys=['current_waypoint'],
             output_keys=['current_waypoint']
         )
@@ -21,15 +21,18 @@ class Entertain(smach.State):
     def execute(self, userdata):
         self.card = False
         self.sub = rospy.Subscriber("/socialCardReader/commands", String, callback=self.callback)
-        rospy.loginfo("Let me entertain you!")
+        rospy.loginfo("Showing entertainment interface.")
         strands_webserver.client_utils.display_relative_page(self.display_no, "entertainment.html")
         rospy.loginfo("I am at: " + userdata.current_waypoint)
-        while not self.card and not rospy.is_shutdown():
+        while not self.card and not rospy.is_shutdown() and not self.preempt_requested():
             pass
+        if self.preempt_requested():
+            return 'killall'
         return 'key_card'
 
     def callback(self, data):
-        print "got card:", data
+        rospy.loginfo("got card: " + str(data.data))
         if data.data == "PAUSE_WALK":
             self.card = True
             self.sub.unregister()
+            self.sub = None

--- a/aaf_walking_group/src/aaf_walking_group/guide_interface.py
+++ b/aaf_walking_group/src/aaf_walking_group/guide_interface.py
@@ -74,5 +74,4 @@ class GuideInterface(smach.State):
     def cancel_srv(self, req):
         rospy.loginfo("Cancelation of guide inteface requested.")
         self._client.cancel_all_goals()
-
         return EmptyResponse()

--- a/aaf_walking_group/src/aaf_walking_group/guide_interface.py
+++ b/aaf_walking_group/src/aaf_walking_group/guide_interface.py
@@ -3,7 +3,9 @@
 import rospy
 import smach
 import actionlib
+from actionlib_msgs.msg import GoalStatus
 from aaf_walking_group.msg import InterfaceAction, InterfaceGoal
+from std_srvs.srv import Empty, EmptyResponse
 
 class GuideInterface(smach.State):
     def __init__(self, waypointset):
@@ -21,9 +23,11 @@ class GuideInterface(smach.State):
             InterfaceAction
         )
         self._client.wait_for_server()
-        rospy.loginfo("...done")
+        rospy.loginfo(" ...done")
+        self.srv = None
 
     def execute(self, userdata):
+        self.srv = rospy.Service('/walking_group/guide_interface/cancel', Empty, self.cancel_srv)
         rospy.loginfo("Showing guide interface")
         rospy.sleep(1)
 
@@ -45,10 +49,30 @@ class GuideInterface(smach.State):
         goal.next_point = next_waypoint
         rospy.loginfo("Sending a goal to interface server...")
         self._client.send_goal_and_wait(goal)
-        result = self._client.get_result()
-        rospy.loginfo("Got the chosen next waypoint.")
-        next_waypoint = result.chosen_point
+        state = self._client.get_state()
+        self.srv.shutdown()
+        if state == GoalStatus.SUCCEEDED:
+            result = self._client.get_result()
+            rospy.loginfo("Got the chosen next waypoint.")
+            next_waypoint = result.chosen_point
 
-        rospy.loginfo("I will go to: " + next_waypoint)
-        userdata.waypoint = next_waypoint
-        return 'move_to_point'
+            rospy.loginfo("I will go to: " + next_waypoint)
+            userdata.waypoint = next_waypoint
+            return 'move_to_point'
+        elif self._preempt_requested:
+            return 'killall'
+        else:
+            return 'aborted'
+
+    def request_preempt(self):
+        """Overload the preempt request method to cancel interface goal."""
+        self._client.cancel_all_goals()
+        smach.State.request_preempt(self)
+        self.srv.shutdown()
+        rospy.logwarn("Guide Interface Preempted!")
+
+    def cancel_srv(self, req):
+        rospy.loginfo("Cancelation of guide inteface requested.")
+        self._client.cancel_all_goals()
+
+        return EmptyResponse()

--- a/aaf_walking_group/src/aaf_walking_group/guiding.py
+++ b/aaf_walking_group/src/aaf_walking_group/guiding.py
@@ -4,52 +4,67 @@ import rospy
 import smach
 from copy import deepcopy
 import actionlib
-from aaf_walking_group.msg import GuidingAction, GuidingActionGoal, GuidingGoal
-from music_player.srv import MusicPlayerService, MusicPlayerServiceRequest, MusicPlayerServiceResponse
+from aaf_walking_group.msg import GuidingAction, GuidingGoal
+from music_player.srv import MusicPlayerService, MusicPlayerServiceRequest
 
 
 class Guiding(smach.State):
     def __init__(self):
         smach.State.__init__(
             self,
-            outcomes=['reached_point', 'reached_final_point', 'key_card'],
+            outcomes=['reached_point', 'reached_final_point', 'key_card', 'killall'],
             input_keys=['waypoint'],
             output_keys=['current_waypoint']
         )
+        rospy.loginfo("Creating guiding client...")
+        self.nav_client = actionlib.SimpleActionClient("guiding", GuidingAction)
+        self.nav_client.wait_for_server()
+        rospy.loginfo(" ... done")
+
+    def music_control(self, command):
+        try:
+            music_client = rospy.ServiceProxy('music_player_service', MusicPlayerService)
+            if command == "play":
+                music_client(MusicPlayerServiceRequest.PLAY)
+            elif command == "pause":
+                music_client(MusicPlayerServiceRequest.PAUSE)
+        except rospy.ServiceException, e:
+            rospy.logwarn("Service call failed: %s" % e)
 
     def execute(self, userdata):
         rospy.loginfo("Guiding group")
         rospy.sleep(1)
         rospy.loginfo("I am going to: " + userdata.waypoint)
         # Action server that does all the black magic for navigation
-        nav_client = actionlib.SimpleActionClient("guiding", GuidingAction)
-        nav_client.wait_for_server()
 
-        try:
-            music_client = rospy.ServiceProxy('music_player_service', MusicPlayerService)
-            music_client(MusicPlayerServiceRequest.PLAY)
-        except rospy.ServiceException, e:
-            rospy.logwarn("Service call failed: %s" % e)
+        self.music_control("play")
 
         goal = GuidingGoal()
         print goal
         goal.waypoint = userdata.waypoint
-        nav_client.send_goal_and_wait(goal)
+        self.nav_client.send_goal_and_wait(goal)
 
-        try:
-            music_client = rospy.ServiceProxy('music_player_service', MusicPlayerService)
-            music_client(MusicPlayerServiceRequest.PAUSE)
-        except rospy.ServiceException, e:
-            rospy.logwarn("Service call failed: %s" % e)
+        self.music_control("pause")
 
-        # If successful and not last point
-        userdata.current_waypoint = deepcopy(userdata.waypoint)
-        return 'reached_point'
+        if self.preempt_requested():
+            return 'killall'
+        else:
 
-        # If successful and last point
-        userdata.current_waypoint = deepcopy(userdata.waypoint)
-        return 'reached_final_point'
+            # If successful and not last point
+            userdata.current_waypoint = deepcopy(userdata.waypoint)
+            return 'reached_point'
 
-        # If aborted by showing key card
-        userdata.current_waypoint = deepcopy(userdata.waypoint)
-        return 'key_card'
+            # If successful and last point
+            userdata.current_waypoint = deepcopy(userdata.waypoint)
+            return 'reached_final_point'
+
+            # If aborted by showing key card
+            userdata.current_waypoint = deepcopy(userdata.waypoint)
+            return 'key_card'
+
+    def request_preempt(self):
+        """Overload the preempt request method to cancel guiding."""
+        self.music_control("pause")
+        self.nav_client.cancel_all_goals()
+        smach.State.request_preempt(self)
+        rospy.logwarn("Guiding Preempted!")

--- a/aaf_waypoint_sounds/launch/waypoint_sounds.launch
+++ b/aaf_waypoint_sounds/launch/waypoint_sounds.launch
@@ -2,7 +2,7 @@
     <arg name="music_set" default="aaf_walking_group"/>
     <!-- This will be inside .ros unless provided with full path -->
     <arg name="audio_folder" default="aaf_waypoint_sounds"/>
-    <arg name="waypoint_sounds" default='{"WayPoint1": "fringilla-coelebs.mp3", "WayPoint2": "larus-ridibundus.mp3", "WayPoint3": "melanitta-fusca.mp3", "WayPoint4": "turdus-merula.mp3"}'/>
+    <arg name="waypoint_sounds_file"/>
 
     <node pkg="aaf_waypoint_sounds" type="aaf_waypoint_player.py" name="aaf_waypoint_player" output="screen">
         <!-- The set in mongodb_media_server to use for the waypoint sounds -->
@@ -10,7 +10,7 @@
         <!-- The folder to store the media files while being player -->
         <param name="audio_folder" type="string" value="$(arg audio_folder)"/>
         <!-- Json dictionary mapping waypoints to mp3 files, see above for example -->
-        <param name="waypoint_sounds" type="string" value="$(arg waypoint_sounds)"/>
+        <rosparam command="load" file="$(arg waypoint_sounds_file)"/>
     </node>
 
 </launch>


### PR DESCRIPTION
This includes following new features:
- All states and action servers are now preemptable: closes #8 
- Offering a service for preemption of the whole state machine: `/walking_group/cancel` (#9) 
- Reading waypoint sounds configuration json from yaml file
- If 'abort' is pressed in the guide interface it will now correctly transition back to the entertain state
