### PR TITLE
Walking group implementing full state machine functionality and bug fixes

### DIFF
--- a/aaf_walking_group/action/StateMachine.action
+++ b/aaf_walking_group/action/StateMachine.action
@@ -1,4 +1,3 @@
 string group
-string start_waypoint
 ---
 ---

--- a/aaf_walking_group/scripts/guiding_action.py
+++ b/aaf_walking_group/scripts/guiding_action.py
@@ -90,16 +90,14 @@ class GuidingServer():
         rospy.logwarn("Guiding action preempt requested")
         self.client.cancel_all_goals()
         self.empty_client.cancel_all_goals()
-        while not rospy.is_shutdown():
-            try:
-                pause_service = rospy.ServiceProxy(
-                    '/monitored_navigation/pause_nav',
-                    PauseResumeNav
-                )
-                pause_service(0)
-                break
-            except rospy.ServiceException, e:
-                print "Service call failed: %s" % e
+        try:
+            pause_service = rospy.ServiceProxy(
+                '/monitored_navigation/pause_nav',
+                PauseResumeNav
+            )
+            pause_service(0)
+        except rospy.ServiceException, e:
+            rospy.logwarn("Service call failed: %s" % e)
 
     def _on_node_shutdown(self):
         self.client.cancel_all_goals()

--- a/aaf_walking_group/src/aaf_walking_group/guiding.py
+++ b/aaf_walking_group/src/aaf_walking_group/guiding.py
@@ -3,19 +3,26 @@
 import rospy
 import smach
 from copy import deepcopy
+from std_msgs.msg import String
 import actionlib
+from actionlib_msgs.msg import GoalStatus
 from aaf_walking_group.msg import GuidingAction, GuidingGoal
 from music_player.srv import MusicPlayerService, MusicPlayerServiceRequest
 
 
 class Guiding(smach.State):
-    def __init__(self):
+    def __init__(self, waypoints):
         smach.State.__init__(
             self,
             outcomes=['reached_point', 'reached_final_point', 'key_card', 'killall'],
             input_keys=['waypoint'],
             output_keys=['current_waypoint']
         )
+        self.waypoints = waypoints
+        self.last_waypoint = waypoints[str(max([int(x) for x in waypoints.keys()]))]
+        self.previous_waypoint = waypoints[str(min([int(x) for x in waypoints.keys()]))]
+        self.sub = None
+        self.card = False
         rospy.loginfo("Creating guiding client...")
         self.nav_client = actionlib.SimpleActionClient("guiding", GuidingAction)
         self.nav_client.wait_for_server()
@@ -34,33 +41,47 @@ class Guiding(smach.State):
     def execute(self, userdata):
         rospy.loginfo("Guiding group")
         rospy.sleep(1)
+        self.card = False
+
         rospy.loginfo("I am going to: " + userdata.waypoint)
         # Action server that does all the black magic for navigation
+        for elem in self.waypoints.items():
+            if elem[1] == userdata.waypoint:
+                key = str(int(elem[0])-1)
+                if not key in self.waypoints.keys():
+                    key = "1"
+                self.previous_waypoint = self.waypoints[key]
 
         self.music_control("play")
 
         goal = GuidingGoal()
-        print goal
         goal.waypoint = userdata.waypoint
-        self.nav_client.send_goal_and_wait(goal)
+        if not self.card:
+            self.nav_client.send_goal(goal)
+            # Necessary to account for seeing the card immediately after the goal was sent.
+            # That leads to the goal being pending while trying to cancel and thefore not
+            # cancelling, loosing every chance of doing so. Solution: wait until not pending
+            # before subscribing to card reader for preempt callback.
+            while self.nav_client.get_state() == GoalStatus.PENDING:
+                rospy.sleep(0.01)
+            self.sub = rospy.Subscriber("/socialCardReader/commands", String, callback=self.callback)
+            self.nav_client.wait_for_result()
+            state = self.nav_client.get_state()
 
         self.music_control("pause")
 
-        if self.preempt_requested():
+        if self.preempt_requested() and not self.card:
             return 'killall'
-        else:
-
-            # If successful and not last point
-            userdata.current_waypoint = deepcopy(userdata.waypoint)
-            return 'reached_point'
-
-            # If successful and last point
-            userdata.current_waypoint = deepcopy(userdata.waypoint)
-            return 'reached_final_point'
-
-            # If aborted by showing key card
-            userdata.current_waypoint = deepcopy(userdata.waypoint)
+        elif self.preempt_requested() and self.card:
+            userdata.current_waypoint = self.previous_waypoint
             return 'key_card'
+        else:
+            if state == GoalStatus.SUCCEEDED and not goal.waypoint == self.last_waypoint:
+                userdata.current_waypoint = deepcopy(userdata.waypoint)
+                return 'reached_point'
+            elif state == GoalStatus.SUCCEEDED and goal.waypoint == self.last_waypoint:
+                userdata.current_waypoint = deepcopy(userdata.waypoint)
+                return 'reached_final_point'
 
     def request_preempt(self):
         """Overload the preempt request method to cancel guiding."""
@@ -68,3 +89,11 @@ class Guiding(smach.State):
         self.nav_client.cancel_all_goals()
         smach.State.request_preempt(self)
         rospy.logwarn("Guiding Preempted!")
+
+    def callback(self, data):
+        rospy.loginfo("got card: " + str(data.data))
+        if data.data == "PAUSE_WALK":
+            self.card = True
+            self.sub.unregister()
+            self.sub = None
+            self.request_preempt()


### PR DESCRIPTION
- The state machine now actually finishes with success when arriving at the last point.
- The goal only takes the type of group `slow|fast`. The starting waypoint is the first in the list, assuming that the scheduler will get us there.
- Showing the key card during guiding now takes you to the guide interface. The 'Weiter' button will continue to the next waypoint.
- Using the service to start and stop the waypoint sounds when state machine is started and stopped closes #47
