### PR TITLE
making the info_terminal task creation a service

### DIFF
--- a/info_terminal/infremen/CMakeLists.txt
+++ b/info_terminal/infremen/CMakeLists.txt
@@ -22,7 +22,7 @@ include_directories(${catkin_INCLUDE_DIRS})
 
 add_executable(infremen src/infremen.cpp)
 
-add_dependencies(infremen ${catkin_EXPORTED_TARGETS} mongodb_store)
+add_dependencies(infremen ${catkin_EXPORTED_TARGETS} mongodb_store infremen_generate_messages_cpp)
 
 add_library(infremen_frelement src/CFrelement.cpp)
 add_library(infremen_timer src/CTimer.cpp)

--- a/info_terminal/infremen/CMakeLists.txt
+++ b/info_terminal/infremen/CMakeLists.txt
@@ -1,9 +1,20 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(infremen)
 
-find_package(catkin REQUIRED COMPONENTS  mongodb_store roscpp strands_executive_msgs std_msgs std_srvs strands_navigation_msgs mongodb_store_msgs geometry_msgs) 
+find_package(catkin REQUIRED COMPONENTS  
+	mongodb_store roscpp strands_executive_msgs std_msgs std_srvs
+	strands_navigation_msgs mongodb_store_msgs geometry_msgs
+	message_generation) 
 
 set ( CMAKE_CXX_FLAGS "-Ofast -march=native -mno-avx -ggdb")
+
+## Generate services in the 'srv' folder
+add_service_files(
+   FILES
+   CreateInFremenTask.srv
+)
+
+generate_messages(DEPENDENCIES geometry_msgs std_msgs strands_executive_msgs)
 
 catkin_package(CATKIN_DEPENDS roscpp strands_executive_msgs std_msgs std_srvs strands_navigation_msgs mongodb_store_msgs geometry_msgs mongodb_store)
 

--- a/info_terminal/infremen/srv/CreateInFremenTask.srv
+++ b/info_terminal/infremen/srv/CreateInFremenTask.srv
@@ -1,0 +1,3 @@
+int32 num
+---
+strands_executive_msgs/Task[] tasks


### PR DESCRIPTION
This is to further on being able to more flexibly ask infremen to create tasks and submit them from a python routine. 
Not to be merged yet, but PR created to make sure it runs on jenkins during development.
