### PR TITLE
Improvements to recovery, using indicators, bug fixes

### DIFF
--- a/aaf_walking_group/README.md
+++ b/aaf_walking_group/README.md
@@ -102,11 +102,24 @@ walking_group:
  * `meta_name` _default="waypoint_set"_: The `meta_name` used when inserting the yaml file using `insert_yaml.py`
  * `collection_name` _default="aaf_walking_group"_: The `collection_name` used when inserting the yaml file using `insert_yaml.py`
  * `waypoint_sounds_file` _default="$(find aaf_walking_group)/conf/waypoint_sounds.yaml"_: The waypoint sounds file, describing the waypoints at which to play sounds and which sounds to play; see below.
- * `music_set_group` _default="aaf_walking_group"_: The media server music set to play during the walking phase and via the entertainment interface.
+ * `music_set_group` _default="aaf_walking_group_music"_: The media server music set to play during the walking phase and via the entertainment interface.
  * `music_set_waypoints` _default="aaf_waypoint_sounds"_: The media server music set containing the waypoint sounds.
  * `music_set_jingles` _default="aaf_jingles"_: The media server music set containing the jingles used.
- * `video_set` _default="aaf_video_set"_: The media server video set containing the videos shown during entertainment.
- * `image_set` _default="walking_group_pictures"_: The media server image set containing the pictures shown during entertainment.
+ * `music_set_recovery` _default="aaf_walking_group_recovery_sounds"_: The media server music set containing the jingles used.
+ * `video_set` _default="aaf_walking_group_videos"_: The media server video set containing the videos shown during entertainment.
+ * `image_set` _default="aaf_walking_group_pictures"_: The media server image set containing the pictures shown during entertainment.
+
+**Configuring the recovery behaviours**
+
+Recovery behaviours are dynamically turend on and off during start-up and after the end of the walking group to prevent some of them from kicking in, making the robot drive backwards. Additionally, a custom recovery behaviour, playing a sounds when in trouble, is added. To tell the navigation which behaviour should be used during the group, we create a so-called whitelist which could look like this:
+
+```
+recover_states:
+  sleep_and_retry: [true, .inf]
+  walking_group_help: [true, .inf]
+```
+
+This enables, the `sleep_and_retry` and `walking_group_help` recovery states and sets the possible retries to `inf`. Every behaviour not in this list, will be disabled during the group and reenabled afterwards.
 
 **Configuring the media sets**
 

--- a/aaf_walking_group/conf/recovery_whitelist.yaml
+++ b/aaf_walking_group/conf/recovery_whitelist.yaml
@@ -1,3 +1,7 @@
 recover_states:
   sleep_and_retry: [true, .inf]
   walking_group_help: [true, .inf]
+  recover_bumper: [true, .inf]
+  recover_magnetic_strip: [true, .inf]
+  recover_stuck_on_carpet: [true, .inf]
+  

--- a/aaf_walking_group/conf/recovery_whitelist.yaml
+++ b/aaf_walking_group/conf/recovery_whitelist.yaml
@@ -1,0 +1,3 @@
+recover_states:
+  sleep_and_retry: [true, .inf]
+  walking_group_help: [true, .inf]

--- a/aaf_walking_group/launch/axlaunch/walking_group.launch.xml
+++ b/aaf_walking_group/launch/axlaunch/walking_group.launch.xml
@@ -3,11 +3,13 @@
   <arg name="meta_name" default="waypoint_set"/>
   <arg name="collection_name" default="aaf_walking_group"/>
   <arg name="waypoint_sounds_file" default="$(find aaf_walking_group)/conf/waypoint_sounds.yaml" />
-  <arg name="music_set_group" default="aaf_walking_group"/>
+  <arg name="recovery_whitelist" default="$(find aaf_walking_group)/conf/recovery_whitelist.yaml" />
+  <arg name="music_set_group" default="aaf_walking_group_music"/>
   <arg name="music_set_waypoints" default="aaf_waypoint_sounds"/>
   <arg name="music_set_jingles" default="aaf_jingles"/>
-  <arg name="video_set" default="aaf_video_set"/>
-  <arg name="image_set" default="walking_group_pictures"/>
+  <arg name="music_set_recovery" default="aaf_walking_group_recovery_sounds"/>
+  <arg name="video_set" default="aaf_walking_group_videos"/>
+  <arg name="image_set" default="aaf_walking_group_pictures"/>
 
   <node pkg="aaf_walking_group" type="wait_for_participant.py" name="wait_for_participant" output="screen" respawn="true"/>
   <node pkg="aaf_walking_group" type="guiding_action.py" name="guiding_server" output="screen" respawn="true"/>
@@ -27,6 +29,7 @@
     <param name="mongodb_params/waypointset_name" type="string" value="$(arg waypoint_set)"/>
     <param name="mongodb_params/waypointset_collection" type="string" value="$(arg collection_name)"/>
     <param name="mongodb_params/waypointset_meta" type="string" value="$(arg meta_name)"/>
+    <param name="recovery_whitelist" type="string" value="$(arg recovery_whitelist)"/>
   </node>
 
   <include file="$(find aaf_waypoint_sounds)/launch/waypoint_sounds.launch">
@@ -35,12 +38,15 @@
   </include>
   <node pkg="music_player" type="music_player_server.py" name="music_player_server" output="screen" respawn="true">
     <param name="music_set" type="string" value="$(arg music_set_group)"/>
-    <param name="priority" type="double" value="0.9"/>
+    <param name="priority" type="double" value="0.8"/>
   </node>
   <include file="$(find sound_player_server)/launch/sound_player.launch">
     <arg name="music_set" value="$(arg music_set_jingles)"/>
     <arg name="min_volume" value="0.0"/>
   </include>
-  <node pkg="walking_group_recovery" type="toggle_walking_group_recovery_server.py" name="toggle_walking_group_recovery_server" output="screen" respawn="true"/>
+  <node pkg="walking_group_recovery" type="toggle_walking_group_recovery_server.py" name="toggle_walking_group_recovery_server" output="screen" respawn="true">
+    <param name="music_set" type="string" value="$(arg music_set_recovery)"/>
+    <param name="audio_priority" type="double" value="0.9"/>
+  </node>
 
 </launch>

--- a/aaf_walking_group/package.xml
+++ b/aaf_walking_group/package.xml
@@ -35,6 +35,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>roslaunch_axserver</build_depend>
   <build_depend>roslib</build_depend>
+  <build_depend>rosparam</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>smach</build_depend>
   <build_depend>smach_ros</build_depend>
@@ -65,6 +66,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>roslaunch_axserver</run_depend>
   <run_depend>roslib</run_depend>
+  <run_depend>rosparam</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>smach</run_depend>
   <run_depend>smach_ros</run_depend>

--- a/aaf_walking_group/scripts/aaf_walking_group_state_machine.py
+++ b/aaf_walking_group/scripts/aaf_walking_group_state_machine.py
@@ -127,6 +127,7 @@ class WalkingGroupStateMachine(object):
 
         self.ptu.turnPTU(-180, 10)
         dyn_param = {
+            'timeout': 0.0,
             'gaze_type': 1,
             'detection_angle': 80.0
         }

--- a/aaf_walking_group/scripts/positionOfCard.py
+++ b/aaf_walking_group/scripts/positionOfCard.py
@@ -9,7 +9,6 @@ import numpy as np
 from std_msgs.msg import String
 from geometry_msgs.msg import PoseStamped
 
-VERBOSE=False
 
 class generate_QSR:
 
@@ -17,25 +16,18 @@ class generate_QSR:
         '''Initialize ros publisher, ros subscriber'''
         # topic where we publish
         self.qsr_pub = rospy.Publisher("/socialCardReader/QSR_generator", String, queue_size=10)
-
         # subscribed Topic
         self.Subscriber = rospy.Subscriber("/socialCardReader/cardposition", PoseStamped, self.callback,  queue_size = 1)
-
-        if VERBOSE :
-            print "subscribed to /socialCardReader/cardposition"
-
+        rospy.logdebug("subscribed to /socialCardReader/cardposition")
 
     def callback(self, position):
 
-        if VERBOSE :
-            rospy.loginfo("Card position (x,y,z): [ %f, %f, %f ]"%(position.pose.position.x, position.pose.position.y, position.pose.position.z))
+        rospy.logdebug("Card position (x,y,z): [ %f, %f, %f ]"%(position.pose.position.x, position.pose.position.y, position.pose.position.z))
 
-	if position != []:
+        if position != []:
             distance = np.sqrt((position.pose.position.x)**2 + (position.pose.position.y)**2 + (position.pose.position.z)**2)
             result = 'far' if distance > 2 else 'near'
-
-            if VERBOSE :
-              rospy.loginfo("the card is %s" %result)
+            rospy.logdebug("the card is %s" %result)
 
         # Publish qsr
         self.qsr_pub.publish(result)
@@ -43,8 +35,8 @@ class generate_QSR:
 def main(args):
 
     '''Initializes and cleanup ros node'''
+    rospy.init_node('QSR_generator')
     qsr = generate_QSR()
-    rospy.init_node('QSR_generator', anonymous=True)
     try:
         rospy.spin()
     except KeyboardInterrupt:

--- a/aaf_walking_group/scripts/start_walking_group.py
+++ b/aaf_walking_group/scripts/start_walking_group.py
@@ -43,7 +43,6 @@ class StartWalkingGroup(AbstractTaskServer):
         self.instance_running = msg.data
 
     def create(self, req):
-        print "CALLED"
         task = super(StartWalkingGroup, self).create(req)
         if task.start_node_id == '':
             task.start_node_id = self.location
@@ -109,6 +108,10 @@ class StartWalkingGroup(AbstractTaskServer):
         rospy.loginfo(" ... stopping smach")
         if self.smach_client:
             self.smach_client.cancel_all_goals()
+            rospy.loginfo(" ... waiting for smach to die")
+            # Wait until state machine is dead, so everything is reset bevore killing the components.
+            while not self.smach_client.get_state() == GoalStatus.PREEMPTED and not rospy.is_shutdown():
+                rospy.sleep(0.1)
         rospy.loginfo(" ... stopping launch server")
         self.launch_client.cancel_goal()
         rospy.loginfo(" ... preempted")

--- a/aaf_walking_group/scripts/walking_gui_server.py
+++ b/aaf_walking_group/scripts/walking_gui_server.py
@@ -64,6 +64,7 @@ class WalkingInterfaceServer(object):
         self.ts.registerCallback(self.filter_callback)
 
         self.dyn_client = DynClient('/EBC')
+        self.thread = None
 
         #tell the webserver where it should look for web files to serve
         #http_root = os.path.join(
@@ -148,10 +149,12 @@ class WalkingInterfaceServer(object):
                         self.head.position = [-30, 0]
                         self.head_pub.publish(self.head)
                         #indicate
-                        self.indicate = False
-                        self.thread.join()
+                        if self.thread:
+                            self.indicate = False
+                            self.thread.join()
                         self.indicate = True
                         self.thread = Thread(target=self.blink, args=('right',))
+                        self.thread.start()
                         rospy.loginfo("Moving right...")
                         self.previous_direction = "right"
 
@@ -162,10 +165,12 @@ class WalkingInterfaceServer(object):
                         self.head.position = [30, 0]
                         self.head_pub.publish(self.head)
                         #indicate
-                        self.indicate = False
-                        self.thread.join()
+                        if self.thread:
+                            self.indicate = False
+                            self.thread.join()
                         self.indicate = True
                         self.thread = Thread(target=self.blink, args=('left',))
+                        self.thread.start()
                         rospy.loginfo("Moving left...")
                         self.previous_direction = "left"
 

--- a/aaf_walking_group/scripts/walking_gui_server.py
+++ b/aaf_walking_group/scripts/walking_gui_server.py
@@ -7,7 +7,7 @@ import message_filters
 import time
 import math
 import tf
-import dynamic_reconfigure
+from dynamic_reconfigure.client import Client as DynClient
 import thread
 
 import strands_webserver.client_utils as client_utils
@@ -64,6 +64,8 @@ class WalkingInterfaceServer(object):
             10)
 
         self.ts.registerCallback(self.filter_callback)
+
+        self.dyn_client = DynClient('/EBC')
 
         #tell the webserver where it should look for web files to serve
         #http_root = os.path.join(
@@ -182,13 +184,10 @@ class WalkingInterfaceServer(object):
 
     def switchIndicator(self, isOn, side):
         if side == "left":
-            client = dynamic_reconfigure.client.Client('/EBC')
             params = {'Port0_5V_Enabled' : isOn}
-            client.update_configuration(params)
         else:
-            client = dynamic_reconfigure.client.Client('/EBC')
             params = {'Port1_5V_Enabled' : isOn}
-            client.update_configuration(params)
+        self.dyn_client.update_configuration(params)
 
     def blink(self, side):
         r = rospy.Rate(2)
@@ -198,6 +197,8 @@ class WalkingInterfaceServer(object):
             self.switchIndicator(toggle, side)
             toggle = not toggle
             r.sleep()
+
+        self.switchIndicator(False, side)
 
     def _on_node_shutdown(self):
         self.client.cancel_all_goals()

--- a/aaf_walking_group/scripts/walking_gui_server.py
+++ b/aaf_walking_group/scripts/walking_gui_server.py
@@ -160,7 +160,7 @@ class WalkingInterfaceServer(object):
                                                            'turn_left.html')
                         #indicate
                         self.indicate = True
-                        thread.start_new_thread(self.blink, ('right',))
+                        thread.start_new_thread(self.blink, ('left',))
                         #move head left
                         self.head.position = [30, 0]
                         self.head_pub.publish(self.head)

--- a/aaf_walking_group/scripts/walking_gui_server.py
+++ b/aaf_walking_group/scripts/walking_gui_server.py
@@ -8,11 +8,9 @@ import time
 import math
 import tf
 from dynamic_reconfigure.client import Client as DynClient
-import thread
-
+from threading import Thread
 import strands_webserver.client_utils as client_utils
 from aaf_walking_group.msg import EmptyAction
-#from move_base_msgs.msg import MoveBaseActionGoal
 from nav_msgs.msg import Path
 from strands_navigation_msgs.msg import TopologicalMap, TopologicalRoute
 from sensor_msgs.msg import JointState
@@ -146,24 +144,28 @@ class WalkingInterfaceServer(object):
                     if self.direction == 'right':
                         client_utils.display_relative_page(self.display_no,
                                                            'turn_right.html')
-                        #indicate
-                        self.indicate = True
-                        thread.start_new_thread(self.blink, ('right',))
                         #move head right
                         self.head.position = [-30, 0]
                         self.head_pub.publish(self.head)
+                        #indicate
+                        self.indicate = False
+                        self.thread.join()
+                        self.indicate = True
+                        self.thread = Thread(target=self.blink, args=('right',))
                         rospy.loginfo("Moving right...")
                         self.previous_direction = "right"
 
                     elif self.direction == 'left':
                         client_utils.display_relative_page(self.display_no,
                                                            'turn_left.html')
-                        #indicate
-                        self.indicate = True
-                        thread.start_new_thread(self.blink, ('left',))
                         #move head left
                         self.head.position = [30, 0]
                         self.head_pub.publish(self.head)
+                        #indicate
+                        self.indicate = False
+                        self.thread.join()
+                        self.indicate = True
+                        self.thread = Thread(target=self.blink, args=('left',))
                         rospy.loginfo("Moving left...")
                         self.previous_direction = "left"
 

--- a/aaf_walking_group/src/aaf_walking_group/guide_interface.py
+++ b/aaf_walking_group/src/aaf_walking_group/guide_interface.py
@@ -44,8 +44,9 @@ class GuideInterface(smach.State):
             if elem[1] == userdata.current_waypoint:
                 key = str(int(elem[0])+1)
                 if not key in waypoints.keys():
-                    key = "1"
+                    rospy.logfatal("No next waypoint found")
                 next_waypoint = waypoints[key]
+                break
 
         # Getting the next waypoint from guide interface
         rospy.loginfo("Opening the guide interface...")

--- a/aaf_walking_group/www/image.html
+++ b/aaf_walking_group/www/image.html
@@ -10,7 +10,7 @@
     <script src="roslibjs/include/EventEmitter2/eventemitter2.js"></script>
     <script src="roslibjs/build/roslib.js"></script>
   </head>
-  <body onload="setImage(0)" style="width: 1024px; height: 768px; background-repeat:no-repeat;">
+  <body onload="setImage(0)" style="width: 1000px; height: 750px; background-repeat:no-repeat;">
   
   <!-- Go back to the main page -->
   <a class="button-style liste-button" style="position: absolute; left: 900px; top: 660px; width: 90px; height: 80px;" href="entertainment.html"></a>

--- a/aaf_walking_group/www/video.html
+++ b/aaf_walking_group/www/video.html
@@ -10,7 +10,7 @@
     <script src="roslibjs/include/EventEmitter2/eventemitter2.js"></script>
     <script src="roslibjs/build/roslib.js"></script>
   </head>
-  <body onload="setVideo(0)" style="width: 1024px; height: 768px; background-repeat:no-repeat;">
+  <body onload="setVideo(0)" style="width: 1000px; height: 750px; background-repeat:no-repeat;">
   
   <!-- Go back to the main page -->
   <a class="button-style liste-button" style="position: absolute; left: 900px; top: 660px; width: 90px; height: 80px;" href="entertainment.html"></a>


### PR DESCRIPTION
- recovery behaviour whitelist is now read from file
  - README reflects that as well.
- walking group recovery is now turned on when the goal is active.
- bug fixes and reformatting in position of card node.
- Fixing dimensions for two of the web sites
- Using indicators if there are any (reconfigures both 5V EBCs, shouldn't be used by anything else).
- Setting head tilt to 0 when moving it.
- Bug fix for first and last waypoint being the same
