### PR TITLE
Bringup additions

### DIFF
--- a/aaf_bringup/scripts/aaf_start.sh
+++ b/aaf_bringup/scripts/aaf_start.sh
@@ -41,7 +41,7 @@ tmux select-window -t $SESSION:4
 tmux send-keys "DISPLAY=:0 roslaunch strands_bringup strands_ui.launch"
 
 tmux select-window -t $SESSION:5
-tmux send-keys "DISPLAY=:0 roslaunch strands_bringup strands_navigation.launch map:=/opt/strands/maps/WW_GF_2015_02_22-cropped.yaml with_no_go_map:=false topological_map:=WW_GF_2015_02_22 no_go_map:=/opt/strands/maps/WW_GF_2015_02_22-cropped.yaml with_human_aware:=true"
+tmux send-keys "DISPLAY=:0 roslaunch strands_bringup strands_navigation.launch map:=/opt/strands/maps/WW_GF_2015_02_22-cropped.yaml with_no_go_map:=false topological_map:=WW_GF_2015_02_22 no_go_map:=/opt/strands/maps/WW_GF_2015_02_22-cropped.yaml with_human_aware:=true with_chest_xtion:=true"
 
 tmux select-window -t $SESSION:6
 tmux send-keys "DISPLAY=:0 roslaunch perception_people_launch people_tracker_robot.launch machine:=left-cortex user:=strands"

--- a/aaf_bringup/scripts/aaf_start.sh
+++ b/aaf_bringup/scripts/aaf_start.sh
@@ -29,43 +29,43 @@ tmux select-pane -t 1
 tmux send-keys "htop" C-m
 
 tmux select-window -t $SESSION:1
-tmux send-keys "roslaunch strands_bringup strands_core.launch db_path:=/opt/strands/aaf_datacentre"
+tmux send-keys "DISPLAY=:0 roslaunch strands_bringup strands_core.launch db_path:=/opt/strands/aaf_datacentre"
 
 tmux select-window -t $SESSION:2
-tmux send-keys "roslaunch strands_bringup strands_robot.launch laser:=/dev/laser with_mux:=false"
+tmux send-keys "DISPLAY=:0 roslaunch strands_bringup strands_robot.launch laser:=/dev/laser with_mux:=false"
 
 tmux select-window -t $SESSION:3
-tmux send-keys "roslaunch strands_bringup strands_cameras.launch head_camera:=true head_ip:=left-cortex head_user:=strands chest_camera:=true chest_ip:=right-cortex chest_user:=strands"
+tmux send-keys "DISPLAY=:0 roslaunch strands_bringup strands_cameras.launch head_camera:=true head_ip:=left-cortex head_user:=strands chest_camera:=true chest_ip:=right-cortex chest_user:=strands"
 
 tmux select-window -t $SESSION:4
-tmux send-keys "roslaunch strands_bringup strands_ui.launch"
+tmux send-keys "DISPLAY=:0 roslaunch strands_bringup strands_ui.launch"
 
 tmux select-window -t $SESSION:5
-tmux send-keys "roslaunch strands_bringup strands_navigation.launch map:=/opt/strands/maps/WW_GF_2015_02_22-cropped.yaml with_no_go_map:=false topological_map:=WW_GF_2015_02_22 no_go_map:=/opt/strands/maps/WW_GF_2015_02_22-cropped.yaml with_human_aware:=true"
+tmux send-keys "DISPLAY=:0 roslaunch strands_bringup strands_navigation.launch map:=/opt/strands/maps/WW_GF_2015_02_22-cropped.yaml with_no_go_map:=false topological_map:=WW_GF_2015_02_22 no_go_map:=/opt/strands/maps/WW_GF_2015_02_22-cropped.yaml with_human_aware:=true"
 
 tmux select-window -t $SESSION:6
-tmux send-keys "roslaunch perception_people_launch people_tracker_robot.launch machine:=left-cortex user:=strands"
+tmux send-keys "DISPLAY=:0 roslaunch perception_people_launch people_tracker_robot.launch machine:=left-cortex user:=strands"
 
 tmux select-window -t $SESSION:7
-tmux send-keys "rosrun mongodb_media_server server.py"
+tmux send-keys "DISPLAY=:0 rosrun mongodb_media_server server.py"
 
 tmux select-window -t $SESSION:8
-tmux send-keys "rosrun roslaunch_axserver roslaunch_server.py"
+tmux send-keys "DISPLAY=:0 rosrun roslaunch_axserver roslaunch_server.py"
 
 tmux select-window -t $SESSION:9
-tmux send-keys "roslaunch aaf_bringup aaf_routine.launch calendar:=henry.strands%40hanheide.net topological_map:=aaf"
+tmux send-keys "DISPLAY=:0 roslaunch aaf_bringup aaf_routine.launch calendar:=henry.strands%40hanheide.net topological_map:=aaf"
 
 tmux select-window -t $SESSION:10
-tmux send-keys "rosrun aaf_logging start_stop_logging.py"
+tmux send-keys "DISPLAY=:0 rosrun aaf_logging start_stop_logging.py"
 
 tmux select-window -t $SESSION:11
-tmux send-keys "TODO: info_terminal launch file"
+tmux send-keys "DISPLAY=:0 TODO: info_terminal launch file"
 
 tmux select-window -t $SESSION:12
-tmux send-keys "TODO: Bell bot launch file"
+tmux send-keys "DISPLAY=:0 TODO: Bell bot launch file"
 
 tmux select-window -t $SESSION:13
-tmux send-keys "roslaunch aaf_walking_group task_servers.launch"
+tmux send-keys "DISPLAY=:0 roslaunch aaf_walking_group task_servers.launch"
 
 # Set default window
 tmux select-window -t $SESSION:0

--- a/aaf_bringup/scripts/aaf_start.sh
+++ b/aaf_bringup/scripts/aaf_start.sh
@@ -11,6 +11,13 @@ tmux new-window -t $SESSION:3 -n 'cameras'
 tmux new-window -t $SESSION:4 -n 'ui'
 tmux new-window -t $SESSION:5 -n 'navigation'
 tmux new-window -t $SESSION:6 -n 'ppl_perception'
+tmux new-window -t $SESSION:7 -n 'media_server'
+tmux new-window -t $SESSION:8 -n 'axlaunch_server'
+tmux new-window -t $SESSION:9 -n 'scheduler'
+tmux new-window -t $SESSION:10 -n 'logging'
+tmux new-window -t $SESSION:11 -n 'info_terminal'
+tmux new-window -t $SESSION:12 -n 'bell_bot'
+tmux new-window -t $SESSION:13 -n 'walking_group'
 
 
 tmux select-window -t $SESSION:0
@@ -37,8 +44,28 @@ tmux select-window -t $SESSION:5
 tmux send-keys "roslaunch strands_bringup strands_navigation.launch map:=/opt/strands/maps/WW_GF_2015_02_22-cropped.yaml with_no_go_map:=false topological_map:=WW_GF_2015_02_22 no_go_map:=/opt/strands/maps/WW_GF_2015_02_22-cropped.yaml with_human_aware:=true"
 
 tmux select-window -t $SESSION:6
-#tmux send-keys "roslaunch strands_linda linda_people_perception.launch"
 tmux send-keys "roslaunch perception_people_launch people_tracker_robot.launch machine:=left-cortex user:=strands"
+
+tmux select-window -t $SESSION:7
+tmux send-keys "rosrun mongodb_media_server server.py"
+
+tmux select-window -t $SESSION:8
+tmux send-keys "rosrun roslaunch_axserver roslaunch_server.py"
+
+tmux select-window -t $SESSION:9
+tmux send-keys "roslaunch aaf_bringup aaf_routine.launch calendar:=henry.strands%40hanheide.net topological_map:=aaf"
+
+tmux select-window -t $SESSION:10
+tmux send-keys "rosrun aaf_logging start_stop_logging.py"
+
+tmux select-window -t $SESSION:11
+tmux send-keys "TODO: info_terminal launch file"
+
+tmux select-window -t $SESSION:12
+tmux send-keys "TODO: Bell bot launch file"
+
+tmux select-window -t $SESSION:13
+tmux send-keys "roslaunch aaf_walking_group task_servers.launch"
 
 # Set default window
 tmux select-window -t $SESSION:0


### PR DESCRIPTION
- Adding necessary infrastructure like the media and launch server
- Adding launch files for logging and walking group
- Adding place holders for bellbot and info terminal
- Adding `DISPLAY=:0` in front of everything to allow for pygame support when started from remote PC.

Needs #85 merged
