### PR TITLE
Creating aaf navigation launch file.

### DIFF
--- a/aaf_bringup/launch/aaf_navigation.launch
+++ b/aaf_bringup/launch/aaf_navigation.launch
@@ -1,0 +1,96 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="with_chest_xtion" default="true"/>
+  <arg name="chest_xtion_name" default="chest_xtion"/>
+  <arg name="chest_xtion_machine" default="right-cortex"/>
+  <arg name="chest_xtion_user" default="strands"/>
+
+  <arg name="topo_nav_machine" default="right-cortex"/>
+  <arg name="topo_nav_user" default="strands"/>
+
+  <arg name="map"/>
+  <arg name="with_no_go_map" default="false"/>
+  <arg name="no_go_map" default=""/>
+  <arg name="with_mux" default="false" />
+  <arg name="topological_map"/>
+  <arg name="mon_nav_config_file" default="$(find strands_recovery_behaviours)/config/monitored_nav_config.yaml"/>
+  <arg name="z_stair_threshold" default="0.12"/>
+  <arg name="z_obstacle_threshold" default="0.15"/>
+  <arg name="with_head_xtion" default="false"/>
+  <arg name="with_human_aware" default="true"/>
+
+  <arg name="with_site_movebase_params" default="false"/>
+  <arg name="site_movebase_params" default=""/>
+
+  <arg name="subsample_resolution" default="0.05"/>
+  <arg name="subsample_min_points" default="5"/>
+  <arg name="subsample_skip_points" default="20"/>
+
+  <!-- WARNING: This EBC will be powerded on and off during docking! -->
+  <arg name="lightEBC" default=""/>
+
+  <arg name="machine" default="localhost" />
+  <arg name="user" default="" />
+
+  <!-- NOW when launching in a remote mode it will need the ROS_ENV_LOADER set if not it will leave it empty -->
+  <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true" />
+
+  <!-- strands_movebase -->
+  <include file="$(find strands_movebase)/launch/movebase.launch">
+    <arg name="machine"  value="$(arg machine)"/>
+    <arg name="user"  value="$(arg user)"/>
+
+    <arg name="with_chest_xtion" value="$(arg with_chest_xtion)"/>
+    <arg name="chest_xtion_name" value="$(arg chest_xtion_name)"/>
+    <arg name="chest_xtion_machine" value="$(arg chest_xtion_machine)"/>
+    <arg name="chest_xtion_user" value="$(arg chest_xtion_user)"/>
+
+    <arg name="map" value="$(arg map)"/>
+    <arg name="with_no_go_map" value="$(arg with_no_go_map)"/>
+    <arg name="with_mux" value="$(arg with_mux)"/>
+    <arg name="no_go_map" value="$(arg no_go_map)"/>
+    
+    <arg name="z_stair_threshold" value="$(arg z_stair_threshold)"/>
+    <arg name="z_obstacle_threshold" value="$(arg z_obstacle_threshold)"/>
+    <arg name="with_head_xtion" value="$(arg with_head_xtion)"/>
+
+    <arg name="with_site_movebase_params" value="$(arg with_site_movebase_params)"/>
+    <arg name="site_movebase_params" value="$(arg site_movebase_params)"/>
+
+    <arg name="subsample_resolution" value="$(arg subsample_resolution)"/>
+    <arg name="subsample_min_points" value="$(arg subsample_min_points)"/>
+    <arg name="subsample_skip_points" value="$(arg subsample_skip_points)"/>
+  </include>
+
+  <!--- Docking -->
+  <include unless="$(arg with_mux)" file="$(find scitos_docking)/launch/charging.launch">
+    <arg name="machine"  value="$(arg machine)"/>
+    <arg name="user"  value="$(arg user)"/>
+    <arg name="lightEBC"  value="$(arg lightEBC)"/>
+  </include>
+  <include if="$(arg with_mux)" file="$(find scitos_docking)/launch/charging_mux.launch">
+    <arg name="machine"  value="$(arg machine)"/>
+    <arg name="user"  value="$(arg user)"/>
+    <arg name="lightEBC"  value="$(arg lightEBC)"/>
+  </include>
+
+  <!-- Backtrack server -->
+  <include file="$(find backtrack_behaviour)/launch/backtrack.launch"/> 
+
+  <!--- Topological Navigation (includes monitored_navigation) -->
+  <include file="$(find topological_navigation)/launch/topological_navigation.launch">
+    <arg name="machine"  value="$(arg topo_nav_machine)"/>
+    <arg name="user"  value="$(arg topo_nav_user)"/>
+    <arg name="map" value="$(arg topological_map)"/>
+    <arg name="mon_nav_config_file" value="$(arg mon_nav_config_file)"/>
+  </include>
+
+  <node name="odometry_mileage" pkg="odometry_mileage" type="odometry_mileage"/>
+  <!-- <node name="door_pass_node" pkg="door_pass" type="door_pass.py" output="screen" /> --> <!-- Might still be needed -->
+
+  <group if="$(arg with_human_aware)">
+    <node name="gaze_at_pose" pkg="strands_gazing" type="gaze_at_pose"/>
+    <node name="pose_extractor" pkg="pose_extractor" type="extract_last_pose_from_path.py"/>
+    <node name="human_aware_navigation" pkg="strands_human_aware_navigation" type="human_aware_navigation.py"/>
+  </group>
+</launch>

--- a/aaf_bringup/launch/aaf_routine.launch
+++ b/aaf_bringup/launch/aaf_routine.launch
@@ -9,7 +9,7 @@
     <!-- NOW when launching in a remote mode it will need the ROS_ENV_LOADER set if not it will leave it empty -->
     <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true" />
 
-    <include file="$(find task_executor)/task-scheduler.launch">
+    <include file="$(find task_executor)/task-scheduler-mdp.launch">
         <arg name="topological_map" value="$(arg topological_map)"/>
     </include>
 

--- a/aaf_bringup/scripts/aaf_start.sh
+++ b/aaf_bringup/scripts/aaf_start.sh
@@ -41,7 +41,7 @@ tmux select-window -t $SESSION:4
 tmux send-keys "DISPLAY=:0 roslaunch strands_bringup strands_ui.launch"
 
 tmux select-window -t $SESSION:5
-tmux send-keys "DISPLAY=:0 roslaunch strands_bringup strands_navigation.launch map:=/opt/strands/maps/WW_GF_2015_02_22-cropped.yaml with_no_go_map:=false topological_map:=WW_GF_2015_02_22 no_go_map:=/opt/strands/maps/WW_GF_2015_02_22-cropped.yaml with_human_aware:=true with_chest_xtion:=true"
+tmux send-keys "DISPLAY=:0 roslaunch aaf_bringup aaf_navigation.launch map:=/opt/strands/maps/WW_GF_2015_02_22-cropped.yaml topological_map:=WW_GF_2015_02_22"
 
 tmux select-window -t $SESSION:6
 tmux send-keys "DISPLAY=:0 roslaunch perception_people_launch people_tracker_robot.launch machine:=left-cortex user:=strands"


### PR DESCRIPTION
Don't need to start everything like ramp climb and door pass only if we see it is necessary during pre-deployment. Setting sensible default values for machine names and users ()Needs of course to bhe changed to names used in Werner set-up during pre-deployment). Also, explicitly launching the mdp planner in routine launch file.

Starting toponav and 3D obstacle avoidance on side PC. The traffic caused by this is:
- 3D: ~3MBit/s
- TopoNav: ~1.5MBit/s when idle, ~2.5 MBit/s when navigating

Currently the right side PC has mary, the chest camera, the 3D avoidance, and topo nav running on it. Memory used: 1GB, Avarage CPU usage over all 8: 15%.

Can therefore take a lot more.
