### PR TITLE
Distributing processes to side PCs

### DIFF
--- a/aaf_bringup/scripts/aaf_start.sh
+++ b/aaf_bringup/scripts/aaf_start.sh
@@ -53,7 +53,7 @@ tmux select-window -t $SESSION:8
 tmux send-keys "DISPLAY=:0 rosrun roslaunch_axserver roslaunch_server.py"
 
 tmux select-window -t $SESSION:9
-tmux send-keys "DISPLAY=:0 roslaunch aaf_bringup aaf_routine.launch calendar:=henry.strands%40hanheide.net topological_map:=aaf"
+tmux send-keys "DISPLAY=:0 roslaunch aaf_bringup aaf_routine.launch calendar:=henry.strands%40hanheide.net machine:=right-cortex user:=strands"
 
 tmux select-window -t $SESSION:10
 tmux send-keys "DISPLAY=:0 rosrun aaf_logging start_stop_logging.py"

--- a/aaf_logging/launch/axlaunch/loggers.launch.xml
+++ b/aaf_logging/launch/axlaunch/loggers.launch.xml
@@ -1,0 +1,21 @@
+<launch>
+    <arg name="bool_stamped_publisher_topic" default="/logging_manager/log_stamped"/>
+
+    <arg name="machine" default="localhost" />
+    <arg name="user" default="" />
+
+    <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true"/>
+
+    <include file="$(find vision_people_logging)/launch/logging_ubd.launch">
+        <arg name="machine" value="$(arg machine)"/>
+        <arg name="user" value="$(arg user)"/>
+        <arg name="manager_topic" value="$(arg bool_stamped_publisher_topic)"/>
+    </include>
+
+    <include file="$(find bayes_people_tracker_logging)/launch/logging.launch">
+        <arg name="machine" value="$(arg machine)"/>
+        <arg name="user" value="$(arg user)"/>
+        <arg name="manager_topic" value=""/>
+    </include>
+
+</launch>

--- a/aaf_logging/launch/logging.launch
+++ b/aaf_logging/launch/logging.launch
@@ -9,8 +9,8 @@
     <arg name="bool_publisher_topic" default="/logging_manager/log"/>
     <arg name="bool_stamped_publisher_topic" default="/logging_manager/log_stamped"/>
 
-    <arg name="machine" default="right-cortex" />
-    <arg name="user" default="strands" />
+    <arg name="machine" default="localhost" />
+    <arg name="user" default="" />
 
     <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="false"/>
 

--- a/aaf_logging/launch/logging.launch
+++ b/aaf_logging/launch/logging.launch
@@ -9,12 +9,16 @@
     <arg name="bool_publisher_topic" default="/logging_manager/log"/>
     <arg name="bool_stamped_publisher_topic" default="/logging_manager/log_stamped"/>
 
-    <arg name="machine" default="localhost" />
-    <arg name="user" default="" />
+    <arg name="machine" default="right-cortex" />
+    <arg name="user" default="strands" />
 
-    <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true"/>
+    <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="false"/>
+
+    <node pkg="aaf_logging" type="start_stop_logging.py" name="logging_server" output="screen" respawn="true"/>
 
     <include file="$(find topological_logging_manager)/launch/manager.launch">
+        <arg name="machine" value="$(arg machine)"/>
+        <arg name="user" value="$(arg user)"/>
         <arg name="white_list_file" value="$(arg white_list_file)"/>
         <arg name="current_node_topic" value="$(arg current_node_topic)"/>
         <arg name="closest_node_topic" value="$(arg closest_node_topic)"/>
@@ -24,14 +28,6 @@
         <arg name="publishing_rate" value="$(arg publishing_rate)"/>
         <arg name="bool_publisher_topic" value="$(arg bool_publisher_topic)"/>
         <arg name="bool_stamped_publisher_topic" value="$(arg bool_stamped_publisher_topic)"/>
-    </include>
-
-    <include file="$(find vision_people_logging)/launch/logging_ubd.launch">
-        <arg name="manager" value="$(arg bool_stamped_publisher_topic)"/>
-    </include>
-
-    <include file="$(find bayes_people_tracker_logging)/launch/logging.launch">
-        <arg name="manager_topic" value=""/>
     </include>
 
 </launch>

--- a/aaf_logging/scripts/start_stop_logging.py
+++ b/aaf_logging/scripts/start_stop_logging.py
@@ -22,7 +22,7 @@ class Logger():
             self.running = False
             lg = launchGoal()
             lg.pkg = "aaf_logging"
-            lg.launch_file = "logging.launch"
+            lg.launch_file = "loggers.launch.xml"
             lg.monitored_topics.append("/logging_manager/log_stamped")
             self.launch_client.send_goal(lg, feedback_cb=self.feedback_cb)
             while not self.is_running():

--- a/aaf_walking_group/README.md
+++ b/aaf_walking_group/README.md
@@ -98,6 +98,8 @@ walking_group:
 
 `walking_group_slow` and `walking_group_fast` is used to create two action servers with the corresponding name, therefore these names have to be unique. The number of action servers is dynamic and can be changed by adding another entry to this file. `group` is used to identify the specific set of waypoints from the datacentre (see above); `slow` or `fast` in our case. `start_location` is the waypoint to which the scheduler sends the robot at the beginning of the task and should be the same as the first waypoint in the list above; `WayPoint34` in our case. The `max_duration` is another argument for the schaduler which tells it how long the group task lasts in the worst case. If this time is reached it will assume that the task failed and preempt it. The `parameters` and `values` fields are used together to create the start-up parameters for the internally used launch file:
 
+ * `head_machine` _default="localhost"_: The machine to which the head_camera is connected. The social card reader and position of card will be started there.
+ * `head_user` _default=""_: The user of the machine to which the head_camera is connected. The social card reader and position of card will be started there.
  * `waypoint_set` _default="aaf_waypoints"_: The `dataset_name` used when inserting the yaml file using `insert_yaml.py`
  * `meta_name` _default="waypoint_set"_: The `meta_name` used when inserting the yaml file using `insert_yaml.py`
  * `collection_name` _default="aaf_walking_group"_: The `collection_name` used when inserting the yaml file using `insert_yaml.py`

--- a/aaf_walking_group/launch/axlaunch/walking_group.launch.xml
+++ b/aaf_walking_group/launch/axlaunch/walking_group.launch.xml
@@ -1,6 +1,6 @@
 <launch>
-  <arg name="head_machine" default="left-cortex"/>
-  <arg name="head_user" default="strands"/>
+  <arg name="head_machine" default="localhost"/>
+  <arg name="head_user" default=""/>
   <arg name="waypoint_set" default="aaf_waypoints"/>
   <arg name="meta_name" default="waypoint_set"/>
   <arg name="collection_name" default="aaf_walking_group"/>

--- a/aaf_walking_group/launch/axlaunch/walking_group.launch.xml
+++ b/aaf_walking_group/launch/axlaunch/walking_group.launch.xml
@@ -1,4 +1,6 @@
 <launch>
+  <arg name="head_machine" default="left-cortex"/>
+  <arg name="head_user" default="strands"/>
   <arg name="waypoint_set" default="aaf_waypoints"/>
   <arg name="meta_name" default="waypoint_set"/>
   <arg name="collection_name" default="aaf_walking_group"/>
@@ -11,6 +13,8 @@
   <arg name="video_set" default="aaf_walking_group_videos"/>
   <arg name="image_set" default="aaf_walking_group_pictures"/>
 
+  <machine name="$(arg head_machine)" address="$(arg head_machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg head_user)" default="false"/>
+
   <node pkg="aaf_walking_group" type="wait_for_participant.py" name="wait_for_participant" output="screen" respawn="true"/>
   <node pkg="aaf_walking_group" type="guiding_action.py" name="guiding_server" output="screen" respawn="true"/>
   <node pkg="aaf_walking_group" type="media_server.py" name="image_server" output="screen" respawn="true">
@@ -21,15 +25,17 @@
     <param name="media_set" type="string" value="$(arg video_set)"/>
     <param name="media_set_type" type="string" value="Video"/>
   </node>
-  <node pkg="social_card_reader" type="social_card_reader" name="social_card_reader" output="screen" respawn="true"/>
   <node pkg="aaf_walking_group" type="interface_server.py" name="interface_server" output="screen" respawn="true"/>
   <node pkg="aaf_walking_group" type="walking_gui_server.py" name="walking_interface_server" output="screen" respawn="true"/>
-  <node pkg="aaf_walking_group" type="positionOfCard.py" name="QSR_generator" output="screen" respawn="true"/>
   <node pkg="aaf_walking_group" type="aaf_walking_group_state_machine.py" name="walking_group_smach" output="screen" respawn="true">
     <param name="mongodb_params/waypointset_name" type="string" value="$(arg waypoint_set)"/>
     <param name="mongodb_params/waypointset_collection" type="string" value="$(arg collection_name)"/>
     <param name="mongodb_params/waypointset_meta" type="string" value="$(arg meta_name)"/>
     <param name="recovery_whitelist" type="string" value="$(arg recovery_whitelist)"/>
+  </node>
+  <node pkg="walking_group_recovery" type="toggle_walking_group_recovery_server.py" name="toggle_walking_group_recovery_server" output="screen" respawn="true">
+    <param name="music_set" type="string" value="$(arg music_set_recovery)"/>
+    <param name="audio_priority" type="double" value="0.9"/>
   </node>
 
   <include file="$(find aaf_waypoint_sounds)/launch/waypoint_sounds.launch">
@@ -44,9 +50,8 @@
     <arg name="music_set" value="$(arg music_set_jingles)"/>
     <arg name="min_volume" value="0.0"/>
   </include>
-  <node pkg="walking_group_recovery" type="toggle_walking_group_recovery_server.py" name="toggle_walking_group_recovery_server" output="screen" respawn="true">
-    <param name="music_set" type="string" value="$(arg music_set_recovery)"/>
-    <param name="audio_priority" type="double" value="0.9"/>
-  </node>
+  
+  <node pkg="social_card_reader" type="social_card_reader" name="social_card_reader" output="screen" respawn="true" machine="$(arg head_machine)"/>
+  <node pkg="aaf_walking_group" type="positionOfCard.py" name="QSR_generator" output="screen" respawn="true" machine="$(arg head_machine)"/>
 
 </launch>


### PR DESCRIPTION
To reduce the load on the main PC and save precious memory, related to #88, I now run several of the processes on the side PCs.
- Scheduler is running on chest cam side PC
- topological logging manager is now constantly running on chest cam PC
- social card reader during walking group is running on head cam PC
- QSR generator during walking group is running on head cam PC

Together with the previous changes to navigation and mary this results in following stats on the main PC with the whole current system running (except for info_terminal and bellbot) including walking_group:

RAM: 2100MB
CPUs: 40-60%
Network load: In: 250MBit/s, Out: 10MBit/s

The two side PCs are similar in load with the head cam PC being slightlyhigher due to ppl perception. RAM is around 1-2GB and CPUs are 15%-35%

So far everything seems to work fine, but the scheduler hasn't been tested properly when running on the side PC. Qualitative feedback: much more responsive.

Due to a weird error the logging nodes cannot be run on the side PCs because the datacentre complains. Initiated gitter discussion, will open issue.
