### PR TITLE
Setting default topo map for routine launch file to empty string

### DIFF
--- a/aaf_bringup/launch/aaf_routine.launch
+++ b/aaf_bringup/launch/aaf_routine.launch
@@ -3,7 +3,7 @@
 	<arg name="user" default="" />
 
 	<arg name="calendar" default="henry.strands%40hanheide.net" />
-	<arg name="topological_map"/>
+	<arg name="topological_map" default=""/>
 
 
     <!-- NOW when launching in a remote mode it will need the ROS_ENV_LOADER set if not it will leave it empty -->


### PR DESCRIPTION
 since the mdp planner doesn't need one.
