### PR TITLE
[aaf_logging] Adding a node for filtering rosout based on level

### DIFF
--- a/aaf_logging/CMakeLists.txt
+++ b/aaf_logging/CMakeLists.txt
@@ -38,6 +38,12 @@ catkin_package()
 ## Install ##
 #############
 
+install(PROGRAMS
+  scripts/start_stop_logging.py
+  scripts/filter_rosout.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 install(DIRECTORY launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/aaf_logging/scripts/filter_rosout.py
+++ b/aaf_logging/scripts/filter_rosout.py
@@ -10,7 +10,7 @@ class RosoutFilter():
         rospy.loginfo("Starting aaf logging launcher")
 
         # set level below which we filter
-        self.level = rospy.get_param('~level', 3)
+        self.level = rospy.get_param('~level', 4) # Log.WARN = 4
 
         # register republish topic
         self.logger_pub = rospy.Publisher("/rosout_filtered", Log, queue_size=100)
@@ -20,7 +20,7 @@ class RosoutFilter():
 
     def logger_cb(self, logmsg):
         # if below level, don't log
-        if logmsg.level < level:
+        if logmsg.level < self.level:
             return
         # otherwise, republish into /rosout_filtered
         self.logger_pub.publish(logmsg)

--- a/aaf_logging/scripts/filter_rosout.py
+++ b/aaf_logging/scripts/filter_rosout.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import rospy
+from rosgraph_msgs.msg import Log
+
+class RosoutFilter():
+    def __init__(self):
+        # announce
+        rospy.loginfo("Starting aaf logging launcher")
+
+        # set level below which we filter
+        self.level = rospy.get_param('~level', 3)
+
+        # register republish topic
+        self.logger_pub = rospy.Publisher("/rosout_filtered", Log, queue_size=100)
+
+        # subscribe to logging
+        rospy.Subscriber("/rosout", Log, self.logger_cb)
+
+    def logger_cb(self, logmsg):
+        # if below level, don't log
+        if logmsg.level < level:
+            return
+        # otherwise, republish into /rosout_filtered
+        self.logger_pub.publish(logmsg)
+
+if __name__ == "__main__":
+    rospy.init_node("filter_rosout")
+    rf  = RosoutFilter()
+    rospy.spin()


### PR DESCRIPTION
Added a node that checks the level of rosout message, defaulting to discard everything below `WARN`. Republishes to `/rosout_filtered`. Tested on Werner, works.

Also added an install target for `start_stop_logging.py`. @marc-hanheide 
