### PR TITLE
[aaf_logging] Added throttling to some topics

### DIFF
--- a/aaf_logging/launch/logging.launch
+++ b/aaf_logging/launch/logging.launch
@@ -8,12 +8,14 @@
     <arg name="publishing_rate" default="30"/>
     <arg name="bool_publisher_topic" default="/logging_manager/log"/>
     <arg name="bool_stamped_publisher_topic" default="/logging_manager/log_stamped"/>
+    <arg name="mongodb_host" default="localhost"/>
+    <arg name="mongodb_port" default="62345"/>
 
     <arg name="machine" default="localhost" />
     <arg name="user" default="" />
 
     <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="false"/>
-
+    
     <node pkg="aaf_logging" type="start_stop_logging.py" name="logging_server" output="screen" respawn="true"/>
 
     <node pkg="aaf_logging" type="store_logs_task.py" name="store_logs" output="screen" respawn="true">
@@ -39,7 +41,7 @@
     <node pkg="aaf_logging" type="filter_rosout.py" name="filter_rosout" output="screen" respawn="true"/>
     <node pkg="topic_tools" type="throttle" name="throttle_global_plan" output="screen" respawn="true" args="messages /move_base/DWAPlannerROS/global_plan 0.5 /move_base/DWAPlannerROS/global_plan_throttled"/>
     <node pkg="topic_tools" type="throttle" name="throttle_local_plan" output="screen" respawn="true" args="messages /move_base/DWAPlannerROS/local_plan 0.5 /move_base/DWAPlannerROS/local_plan_throttled"/>
-    <node pkg="mongodb_log" type="mongodb_log_tf" name="tf_logger" output="screen" respawn="true" args="-t /tf -m $(arg machine):62345 -n tf_logger -c roslog.tf -k 0.1 -l 0.1 -g 0.5 -a"/>
+    <node pkg="mongodb_log" type="mongodb_log_tf" name="tf_logger" output="screen" respawn="true" args="-t /tf -m $(arg mongodb_host):$(arg mongodb_port) -n tf_logger -c roslog.tf -k 0.1 -l 0.1 -g 0.5 -a"/>
 
     <!--
     <include file="$(find aaf_logging)/launch/topics.launch">

--- a/aaf_logging/launch/logging.launch
+++ b/aaf_logging/launch/logging.launch
@@ -37,6 +37,9 @@
     </include>
 
     <node pkg="aaf_logging" type="filter_rosout.py" name="filter_rosout" output="screen" respawn="true"/>
+    <node pkg="topic_tools" type="throttle" name="throttle_tf" output="screen" respawn="true" args="messages tf 3 /tf_throttled"/>
+    <node pkg="topic_tools" type="throttle" name="throttle_global_plan" output="screen" respawn="true" args="messages tf 1 /move_base/DWAPlannerROS/global_plan_throttled"/>
+    <node pkg="topic_tools" type="throttle" name="throttle_local_plan" output="screen" respawn="true" args="messages tf 1 /move_base/DWAPlannerROS/local_plan_throttled"/>
 
     <!--
     <include file="$(find aaf_logging)/launch/topics.launch">

--- a/aaf_logging/launch/logging.launch
+++ b/aaf_logging/launch/logging.launch
@@ -37,9 +37,9 @@
     </include>
 
     <node pkg="aaf_logging" type="filter_rosout.py" name="filter_rosout" output="screen" respawn="true"/>
-    <node pkg="topic_tools" type="throttle" name="throttle_tf" output="screen" respawn="true" args="messages tf 3 /tf_throttled"/>
-    <node pkg="topic_tools" type="throttle" name="throttle_global_plan" output="screen" respawn="true" args="messages tf 1 /move_base/DWAPlannerROS/global_plan_throttled"/>
-    <node pkg="topic_tools" type="throttle" name="throttle_local_plan" output="screen" respawn="true" args="messages tf 1 /move_base/DWAPlannerROS/local_plan_throttled"/>
+    <node pkg="topic_tools" type="throttle" name="throttle_global_plan" output="screen" respawn="true" args="messages /move_base/DWAPlannerROS/global_plan 0.5 /move_base/DWAPlannerROS/global_plan_throttled"/>
+    <node pkg="topic_tools" type="throttle" name="throttle_local_plan" output="screen" respawn="true" args="messages /move_base/DWAPlannerROS/local_plan 0.5 /move_base/DWAPlannerROS/local_plan_throttled"/>
+    <node pkg="mongodb_log" type="mongodb_log_tf" name="tf_logger" output="screen" respawn="true" args="-t /tf -m $(arg machine):62345 -n tf_logger -c roslog.tf -k 0.1 -l 0.1 -g 0.5 -a"/>
 
     <!--
     <include file="$(find aaf_logging)/launch/topics.launch">

--- a/aaf_logging/package.xml
+++ b/aaf_logging/package.xml
@@ -50,6 +50,7 @@
   <run_depend>message_generation</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>topological_logging_manager</run_depend>
+  <run_depend>topic_tools</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/aaf_logging/scripts/run_aaf_logger.bash
+++ b/aaf_logging/scripts/run_aaf_logger.bash
@@ -1,6 +1,5 @@
 export AAF_TOPICS="
     /rosout_filtered
-    /tf_throttled
     /robot_pose
     /cmd_vel
     /goal

--- a/aaf_logging/scripts/run_aaf_logger.bash
+++ b/aaf_logging/scripts/run_aaf_logger.bash
@@ -1,14 +1,11 @@
 export AAF_TOPICS="
     /rosout_filtered
-    /tf
+    /tf_throttled
     /robot_pose
     /cmd_vel
     /goal
     /mileage
     /motor_status
-    /head/actual_state
-    /head/cmd_light_state
-    /head/commanded_state
     /barrier_status
     /battery_state
     /bumper
@@ -29,7 +26,6 @@ export AAF_TOPICS="
     /mary_tts/speak
     /strands_emails/goal
     /strands_image_tweets/goal
-    /pygame_player_negotiation
     /chargingServer/goal
     /chargingServer/result
     /chargingServer/cancel
@@ -42,8 +38,8 @@ export AAF_TOPICS="
     /map_updates
     /move_base/NavfnROS/plan
     /move_base/current_goal
-    /move_base/DWAPlannerROS/global_plan
-    /move_base/DWAPlannerROS/local_plan
+    /move_base/DWAPlannerROS/global_plan_throttled
+    /move_base/DWAPlannerROS/local_plan_throttled
     /move_base/goal
     /wait_node/goal
     /wait_node/result


### PR DESCRIPTION
Currently logging tf at 3 hz and the plans at 1 hz. These are the topics that seem to consume the most bandwidth, but it should amount to a only bit more than 20 MB an hour with these rates.

I also removed the /head/\* topics since they consumed a lot of bandwidth (at least in simulation, Rosie down=( ) and since they don't add much. And a couple of other ones that were clearly unnecessary, e.g. logging the local plan twice.

I have a feeling that I am missing some topics but I really went through all the topics that were available on Werner with the basic setup. @cdondrup Do we want to add anything more from walking group?
