### PR TITLE
Add UBD logging node.

### DIFF
--- a/aaf_logging/launch/logging.launch
+++ b/aaf_logging/launch/logging.launch
@@ -50,4 +50,8 @@
     </include>
     -->
 
+    <include file="$(find vision_people_logging)/launch/logging_ubd.launch">
+        <arg name="manager_topic" value="$(arg bool_stamped_publisher_topic)"/>
+    </include>
+
 </launch>


### PR DESCRIPTION
Please check whether this is OK. I don't have an AAF setup ready to test here, but the launchfile works and starts the node.

In a quick informal test, this stores `~380kb` per detection. With last year's G4S max of `~24k` detections in a day, that'd be `~10GB` per day, which fits the 50GB disk easily. I'd like to get it out there and see how many detections we'll get in the first day of testing. I'll add a method for watching db-size and limiting logging accordingly sometime later this week after collecting experience in the G4S test-deployment.

Cross-reference for self: strands-project/g4s_deployment#32
