### PR TITLE
Changing intermediate waypoints for walking group

### DIFF
--- a/aaf_walking_group/conf/waypoints.yaml
+++ b/aaf_walking_group/conf/waypoints.yaml
@@ -12,7 +12,7 @@ slow:
             asking:
                 "WayPoint4"
             intermediate: 
-                1: "WayPoint20"
+                1: "WayPoint88"
         3:
             resting:
                 "Frisoer"
@@ -50,7 +50,7 @@ slow:
             asking:
                 "WalkingGruppeStart"
             intermediate:
-                1: "WayPoint11"
+                1: "WayPoint88"
 fast:
     speed: 0.7
     waypoints:


### PR DESCRIPTION
Today's test has shown that the waypoints I used before are problematic due to the cleaning staff acting as obstacles on the exact waypoint.

Will be tested during the demo later in the day.
