### PR TITLE
Task start delay now dynamically configurable.

### DIFF
--- a/info_terminal/infremen/cfg/infremen.cfg
+++ b/info_terminal/infremen/cfg/infremen.cfg
@@ -8,7 +8,8 @@ gen.add("minimalBatteryLevel", int_t,       0, "The robot will do InfoTerminal a
 gen.add("interactionTimeout",    int_t,    0, "After not interacting for interactionTimeout seconds, the robot might go away",  20, 0,   180 )
 gen.add("maxTaskNumber",   int_t,   0, "Number of time slots to plan ahead", 5,0,10)
 gen.add("taskDuration",    int_t,   0, "Number of seconds to infoterminate", 180,30,240)
-gen.add("taskPriority",    int_t,   0, "Priority of Info Terminal Task", 0,1,10)
-gen.add("verbose",    	   bool_t,    0, "Allow debugging prints", False)
+gen.add("taskPriority",    int_t,   0, "Priority of Info Terminal Task", 1,0,10)
+gen.add("verbose",    	   bool_t,  0, "Allow debugging prints", False)
+gen.add("taskStartDelay", int_t,   0,  "Tasks start at hour:minute:taskStartDelay ", 5,0,59)
 
 exit(gen.generate(PACKAGE, "infremen", "infremen"))

--- a/info_terminal/infremen/cfg/infremen.cfg
+++ b/info_terminal/infremen/cfg/infremen.cfg
@@ -11,5 +11,6 @@ gen.add("taskDuration",    int_t,   0, "Number of seconds to infoterminate", 180
 gen.add("taskPriority",    int_t,   0, "Priority of Info Terminal Task", 1,0,10)
 gen.add("verbose",    	   bool_t,  0, "Allow debugging prints", False)
 gen.add("taskStartDelay", int_t,   0,  "Tasks start at hour:minute:taskStartDelay ", 5,0,59)
+gen.add("rescheduleCheckTime", int_t,   0,  "Tasks are created and modified by rescheduleCheckTime ahead.", 5,0,59)
 
 exit(gen.generate(PACKAGE, "infremen", "infremen"))

--- a/info_terminal/infremen/src/infremen.cpp
+++ b/info_terminal/infremen/src/infremen.cpp
@@ -394,8 +394,6 @@ int createTask(int slot)
 
   		task.start_after =  ros::Time(timeSlots[slot]+taskStartDelay,0);
 		task.end_before = ros::Time(timeSlots[slot]+windowDuration - 2,0);
-		task.max_duration = ros::Duration(taskDuration,0);
-		if (slot > 1 && nodes[slot]==nodes[slot-1]) task.max_duration = ros::Duration(windowDuration-(taskStartDelay-5),0);
 		strands_executive_msgs::AddTask taskAdd;
 		taskAdd.request.task = task;
 		if (taskAdder.call(taskAdd))


### PR DESCRIPTION
The infoterminal tasks start at Hour:Minute:taskStartDelay.
This allows to give more time to re-schedule the infoterminal tasks in cases when the battery is low or when there was an interaction with the infoterminal during the last 3 minutes
