### PR TITLE
[aaf_bringup] Added the reset bumper duration to navigation launch

### DIFF
--- a/aaf_bringup/launch/aaf_navigation.launch
+++ b/aaf_bringup/launch/aaf_navigation.launch
@@ -17,8 +17,9 @@
   <arg name="no_go_map" default=""/>
   <arg name="with_mux" default="false" />
   <arg name="topological_map"/>
-  
+
   <arg name="mon_nav_config_file" default="$(find strands_recovery_behaviours)/config/monitored_nav_config.yaml"/>
+  <arg name="wait_reset_bumper_duration" default="10.0"/>
   <arg name="z_stair_threshold" default="0.12"/>
   <arg name="z_obstacle_threshold" default="0.15"/>
   <arg name="with_head_xtion" default="true"/>
@@ -52,12 +53,12 @@
 
     <arg name="head_xtion_machine" value="$(arg head_xtion_machine)"/>
     <arg name="head_xtion_user" value="$(arg head_xtion_user)"/>
-    
+
     <arg name="map" value="$(arg map)"/>
     <arg name="with_no_go_map" value="$(arg with_no_go_map)"/>
     <arg name="with_mux" value="$(arg with_mux)"/>
     <arg name="no_go_map" value="$(arg no_go_map)"/>
-    
+
     <arg name="z_stair_threshold" value="$(arg z_stair_threshold)"/>
     <arg name="z_obstacle_threshold" value="$(arg z_obstacle_threshold)"/>
     <arg name="with_head_xtion" value="$(arg with_head_xtion)"/>
@@ -83,7 +84,7 @@
   </include>
 
   <!-- Backtrack server -->
-  <include file="$(find backtrack_behaviour)/launch/backtrack.launch"/> 
+  <include file="$(find backtrack_behaviour)/launch/backtrack.launch"/>
 
   <!--- Topological Navigation (includes monitored_navigation) -->
   <include file="$(find topological_navigation)/launch/topological_navigation.launch">
@@ -91,8 +92,9 @@
     <arg name="user"  value="$(arg topo_nav_user)"/>
     <arg name="map" value="$(arg topological_map)"/>
     <arg name="mon_nav_config_file" value="$(arg mon_nav_config_file)"/>
+    <arg name="wait_reset_bumper_duration" value="$(arg wait_reset_bumper_duration)"/>
   </include>
-  
+
     <!--- Emergency Behaviours includes strands emails -->
   <include file="$(find emergency_behaviours)/launch/emergency_behaviours.launch">
     <arg name="machine" value="$(arg topo_nav_machine)"/>


### PR DESCRIPTION
Requires https://github.com/strands-project/strands_navigation/pull/246#issuecomment-101670533 .
