### PR TITLE
added turning angle as a reconfigurable parameter

### DIFF
--- a/aaf_walking_group/cfg/Legibility.cfg
+++ b/aaf_walking_group/cfg/Legibility.cfg
@@ -16,5 +16,11 @@ gen.add("move_head",
     bool_t, 0,
     "Turningmoving the head in the dirction of travel on/off",
     True)
+gen.add("turn_angle",
+    double_t, 0,
+    "turning angle threshold",
+    30.0,
+    45.0,
+    70.0)
 
 exit(gen.generate(PACKAGE, "aaf_walking_group", "Legibility"))

--- a/aaf_walking_group/scripts/walking_gui_server.py
+++ b/aaf_walking_group/scripts/walking_gui_server.py
@@ -88,6 +88,7 @@ class WalkingInterfaceServer(object):
         self.indicators = config["indicators"]
         self.web_page   = config["web_page"]
         self.move_head  = config["move_head"]
+        self.turn_angle = config["turn_angle"]
 
         if self.indicators and not self.dyn_client:
             rospy.loginfo("Waiting for dynamic reconfigure server for 1 sec...")
@@ -126,7 +127,7 @@ class WalkingInterfaceServer(object):
 
             #print math.degrees(angle)
 
-            if abs(math.degrees(angle)) >= 30:
+            if abs(math.degrees(angle)) >= self.turn_angle:
                 if angle > 0:
                     direction = "right"
                 else:


### PR DESCRIPTION
The angle threshold used for the indicators is now a reconfigurable parameter so it can be easily adjusted. I also tried several default values in order to improve the accuracy of the given directions.
