### PR TITLE
Killing the logging when the start stop server is killed

### DIFF
--- a/aaf_logging/scripts/start_stop_logging.py
+++ b/aaf_logging/scripts/start_stop_logging.py
@@ -7,6 +7,7 @@ from roslaunch_axserver.msg import launchAction, launchGoal
 from aaf_logging.msg import EmptyAction
 from strands_executive_msgs.abstract_task_server import AbstractTaskServer
 import time
+import signal as sig
 
 
 class Logger():
@@ -53,6 +54,10 @@ class Logger():
     def is_running(self):
         return self.running
 
+    def signal_handler(self, signal, frame):
+        self.stop_logging()
+        rospy.signal_shutdown("Shutdown requested by signal")
+
 class LoggingServer(AbstractTaskServer):
     def __init__(self, name, llauncher):
         self.name = name
@@ -98,5 +103,9 @@ if __name__ == "__main__":
     l  = Logger()
     l1 = LoggingServer(rospy.get_name()+"_start", l)
     l2 = LoggingServer(rospy.get_name()+"_stop", l)
+    signals = [sig.SIGINT, sig.SIGTERM] # SIGKILL cannot be caught...
+    for i in signals:
+        print i
+        sig.signal(i, l.signal_handler)
     rospy.spin()
 

--- a/aaf_logging/scripts/start_stop_logging.py
+++ b/aaf_logging/scripts/start_stop_logging.py
@@ -105,7 +105,6 @@ if __name__ == "__main__":
     l2 = LoggingServer(rospy.get_name()+"_stop", l)
     signals = [sig.SIGINT, sig.SIGTERM] # SIGKILL cannot be caught...
     for i in signals:
-        print i
         sig.signal(i, l.signal_handler)
     rospy.spin()
 


### PR DESCRIPTION
Currently, the logging is started and stopped via the `start_stop_logging.py` which allows to start and terminate logging via the google calendar. If this server dies, however, while the logging is running, the logging is "detached" from that server and will run until the launch server is killed. To prevent this, the `start_stop_logging.py` now catches `SIGINT` and `SIGTERM` (`SIGKILL` cannot be caught) and stops the logging before shutting down. Hence, when the control server dies, the logging dies.

The parameter `/logging_server/running` is used to show and remember the last status of the server before it was killed. If the logging was running when the server was killed it is restarted automatically the next time the server is restarted. This, together with the respawn flag in the launch file, should prevent that the logging dies or gets detached from the server.
