### PR TITLE
Adding task server to reconfigure infremen

### DIFF
--- a/info_terminal/info_task/cfg/tasks.yaml
+++ b/info_terminal/info_task/cfg/tasks.yaml
@@ -1,0 +1,8 @@
+info_terminal_start:
+    location: "ChargingPoint"
+    parameters:
+        maxTaskNumber: 5
+info_terminal_stop:
+    location: "ChargingPoint"
+    parameters:
+        maxTaskNumber: 0

--- a/info_terminal/info_task/scripts/start_stop_info_terminal.py
+++ b/info_terminal/info_task/scripts/start_stop_info_terminal.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import rospy
+import rosparam
+from info_task.msg import EmptyAction
+from strands_executive_msgs.abstract_task_server import AbstractTaskServer
+from dynamic_reconfigure.client import Client as DynClient
+from dynamic_reconfigure import DynamicReconfigureParameterException as DynException
+
+class Server(AbstractTaskServer):
+    def __init__(self, name, location, parameters):
+        rospy.loginfo("Starting node: %s" % name)
+        self.location = location
+        self.parameters = parameters
+        rospy.loginfo("Using parameters: %s" % str(self.parameters))
+
+        rospy.loginfo(" ... starting action server " + name)
+        super(Server, self).__init__(
+            name=name,
+            action_type=EmptyAction,
+            interruptible=True
+        )
+        rospy.loginfo(" ... started " + name)
+        rospy.loginfo(" ... done " + name)
+
+    def create(self, req):
+        task = super(Server, self).create(req)
+        if task.start_node_id == '':
+            task.start_node_id = self.location
+            task.end_node_id = task.start_node_id
+        if task.max_duration.secs == 0.0:
+            task.max_duration = task.end_before - task.start_after
+        if task.priority == 0:
+            task.priority = 3
+        return task
+
+    def update_configureation(self, client, parameters):
+        try:
+            client.update_configuration(parameters)
+        except DynException as e:
+            rospy.logerr(e)
+            rospy.logwarn("Retrying dynamic reconfigure for infremen")
+            rospy.sleep(1.)
+            if not rospy.is_shutdown():
+                self.update_configureation(client, parameters)
+
+    def execute(self, goal):
+        try:
+            rospy.loginfo("Creating infremen dynamic reconfigure client ...")
+            client = DynClient("/infremen", timeout=10.)
+        except rospy.ROSException as e:
+            rospy.logfatal(e)
+            self.server.set_aborted()
+            return
+        else:
+            rospy.loginfo("Reconfiguring infremen ...")
+            self.update_configureation(client, self.parameters)
+            rospy.loginfo("... done")
+            self.server.set_succeeded()
+        finally:
+            # If server is still running, something went wrong
+            if self.server.is_active():
+                self.server.set_aborted()
+
+
+class StartStop(object):
+
+    def __init__(self):
+        rospy.loginfo("Sarting info terminal reconfigure tasks")
+        paramlist=rosparam.load_file(rospy.get_param("~config_file"))[0][0]
+        self.server_list = []
+        for k, v in paramlist.items():
+            self.server_list.append(Server(
+                name=k,
+                location=v["location"],
+                parameters=v["parameters"]
+            ))
+
+
+if __name__ == "__main__":
+    rospy.init_node("start_stop_info_terminal")
+    s = StartStop()
+    rospy.spin()

--- a/info_terminal/info_task/scripts/start_stop_info_terminal.py
+++ b/info_terminal/info_task/scripts/start_stop_info_terminal.py
@@ -28,7 +28,7 @@ class Server(AbstractTaskServer):
         task = super(Server, self).create(req)
         if task.start_node_id == '':
             task.start_node_id = self.location
-            task.end_node_id = task.start_node_id
+        task.end_node_id = task.start_node_id
         if task.max_duration.secs == 0.0:
             task.max_duration = task.end_before - task.start_after
         if task.priority == 0:

--- a/info_terminal/info_task/scripts/start_stop_info_terminal.py
+++ b/info_terminal/info_task/scripts/start_stop_info_terminal.py
@@ -42,7 +42,7 @@ class Server(AbstractTaskServer):
             rospy.logerr(e)
             rospy.logwarn("Retrying dynamic reconfigure for infremen")
             rospy.sleep(1.)
-            if not rospy.is_shutdown():
+            if not rospy.is_shutdown() and not self.server.is_preempt_requested():
                 self.update_configureation(client, parameters)
 
     def execute(self, goal):

--- a/info_terminal/info_terminal/launch/info_terminal.launch
+++ b/info_terminal/info_terminal/launch/info_terminal.launch
@@ -2,15 +2,19 @@
     <arg name="schedule_directory" default="/home/strands/infremen"/>
     <arg name="collection_name" default="AAFBetaTests"/>
     <arg name="language" default="DE"/>
+    <arg name="tasks_config_file" default="$(find info_task)/cfg/tasks.yaml" />
 
     <!-- This will be inside .ros unless provided with full path -->
 
-    <node pkg="info_task" type="info_task_server.py" name="info_task_server" output="screen"/>
-    <node pkg="infremen" type="infremen" name="infremen" output="screen">
+    <node pkg="info_task" type="start_stop_info_terminal.py" name="start_stop_info_terminal" output="screen" respawn="true">
+        <param name="config_file" value="$(arg tasks_config_file)" />
+    </node>
+    <node pkg="info_task" type="info_task_server.py" name="info_task_server" output="screen" respawn="true"/>
+    <node pkg="infremen" type="infremen" name="infremen" output="screen" respawn="true">
 		<param name="scheduleDirectory" value="$(arg schedule_directory)" />
 		<param name="collectionName" value="$(arg collection_name)" />
     </node>
-    <node pkg="info_terminal_gui" type="info_terminal.py" name="info_terminal_gui" output="screen">
+    <node pkg="info_terminal_gui" type="info_terminal.py" name="info_terminal_gui" output="screen" respawn="true">
         <param name="language" value="$(arg language)" type="string" />
     </node>
 


### PR DESCRIPTION
Since I don't want to get up early every morning to start the robot while @Jailander is on holiday, I created a task server that offers two different tasks `/info_terminal_stop` and `/info_terminal_start`. These can be scheduled via the calendar and call dynamic reconfigure to set the number of max tasks that infremen schedules. I know that we currently have a cronjob to stop infremen but that could also be replaced by this task now.

If you want to reconfigure something else, just add it to the `parameters` field of the config file. Also, by creating a new namespace in the config file, you create a new task that can be scheduled. An example would be setting the min battery level you want to keep. By adding:

``` yaml
info_terminal_min_battery_80:
    location: "ChargingPoint"
    parameters:
        minimalBatteryLevel: 80
```

to the config file before the start of the server, it would also offer a task `/info_terminal_min_battery_80` which reconfigures infremen to keep a battery level of 80%. Might be useful for days where the press is coming, so you make sure that the battery is full enough when the robot is needed by just scheduling this tasks, first thing in the morning.

I guess you get the gist of it...

I also set all the nodes in the launch file to respawn because they weren't.

Needs testing on henry obviously. @marc-hanheide @Jailander @gestom please have a look if I forgot something.

**EDIT**
The `location` field in the config file only specifies the default location. If a different one is given via the calendar, the given location is used and the default ignored.
