### PR TITLE
Catching keyerror to 'fix' facebook news

### DIFF
--- a/info_terminal/info_terminal_gui/scripts/info_terminal.py
+++ b/info_terminal/info_terminal_gui/scripts/info_terminal.py
@@ -156,13 +156,18 @@ class Events(object):
         news = self.fb.get()
         #print news
         events = []
-        items = news['data']
-        for n in items:
-            if 'message' in n:
-                dt = parse(n['created_time'])
-                ds = dt.strftime('%d.%m.%Y')
-                events.append("<h3>" + ds + "</h3><h4>"+n['message']+"</h4>")
-        return events
+	try:
+            items = news['data']
+        except KeyError as e:
+            rospy.logerr(e)
+        else:
+            for n in items:
+                if 'message' in n:
+                    dt = parse(n['created_time'])
+                    ds = dt.strftime('%d.%m.%Y')
+                    events.append("<h3>" + ds + "</h3><h4>"+n['message']+"</h4>")
+        finally:
+            return events
 
     def GET(self):
         app.publish_feedback(Events.id)


### PR DESCRIPTION
Currently, whenever someone clicks on news and there is an error while reading from facebook, they get a nasty stack trace without the chance of getting back to the main gui. This PR just catches this exception and returns an empty array. Hence, the News from HdB will be empty but the page will still show correctly.
