### PR TITLE
[aaf_logging] Add logging_script_server for running logging on demand

### DIFF
--- a/aaf_logging/CMakeLists.txt
+++ b/aaf_logging/CMakeLists.txt
@@ -42,6 +42,8 @@ catkin_package()
 
 install(PROGRAMS
   scripts/start_stop_logging.py
+  scripts/logging_script_server.py
+  scripts/run_aaf_logger.bash
   scripts/filter_rosout.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/aaf_logging/CMakeLists.txt
+++ b/aaf_logging/CMakeLists.txt
@@ -21,6 +21,7 @@ add_action_files(
   FILES
   Empty.action
   StoreAndWait.action
+  RunNode.action
 )
 
 generate_messages(

--- a/aaf_logging/action/RunNode.action
+++ b/aaf_logging/action/RunNode.action
@@ -1,0 +1,6 @@
+#goal definition
+string command
+---
+#result definition
+---
+#feedback

--- a/aaf_logging/scripts/logging_script_server.py
+++ b/aaf_logging/scripts/logging_script_server.py
@@ -1,0 +1,75 @@
+#! /usr/bin/env python
+
+import rospy
+import subprocess
+import signal
+import os
+
+import actionlib
+from strands_executive_msgs.abstract_task_server import AbstractTaskServer
+import aaf_logging.msg
+
+class LoggingScriptServer(AbstractTaskServer):
+
+    def __init__(self, name):
+        rospy.loginfo("Starting node: %s" % name)
+        #self._action_name = name
+        #self._as = actionlib.SimpleActionServer(self._action_name, aaf_logging.msg.RunNodeAction, execute_cb = self.execute_cb)
+        #self._as.start()
+        super(LoggingScriptServer, self).__init__(
+            name=name,
+            action_type=aaf_logging.msg.RunNodeAction,
+            interruptible=True
+        )
+        rospy.loginfo('Server is up')
+
+    def execute(self, goal):
+        # decide whether recording should be started or stopped
+        if goal.command == "start":
+            rospy.loginfo('now the logging should start')
+            command = "rosrun aaf_logging run_aaf_logger.bash"
+            self.p = subprocess.Popen(command, stdin=subprocess.PIPE, preexec_fn=os.setsid, shell=True)
+            rospy.loginfo(self.p.pid)
+
+            # check if the goal is preempted
+            rate = rospy.Rate(1.0)
+            while not rospy.is_shutdown() and not self.server.is_preempt_requested(): # and self.p.poll() is None:
+                rospy.loginfo('Sleeping....')
+                rate.sleep()
+
+            rospy.loginfo('Logging is preempted')
+            os.killpg(os.getpgid(self.p.pid), signal.SIGINT)
+            #if rospy.is_shutdown():
+            #    self.server.set_preempted()
+            #    return
+
+        elif goal.command == "stop":
+            rospy.loginfo('now the logging should stop')
+            rospy.loginfo(self.p.pid)
+            os.killpg(os.getpgid(self.p.pid), signal.SIGINT)
+            rospy.loginfo("I'm done")
+
+        else:
+            rospy.loginfo('goal.command is not valid')
+
+        if not self.server.is_preempt_requested():
+            self.server.set_succeeded()
+        else:
+            self.server.set_preempted()
+
+    def create(self, req):
+        task = super(LoggingScriptServer, self).create(req)
+        if task.start_node_id == "":
+            task.start_node_id = "ChargingPoint"
+        if task.end_node_id == "":
+            task.end_node_id = task.start_node_id
+        if task.max_duration.secs == 0:
+            task.max_duration.secs = 60 # Default execution time: 1min
+        if task.priority == 0:
+            task.priority = 5 # Always start and stop loggin with high priority.
+        return task
+
+if __name__ == '__main__':
+    rospy.init_node('logging_script_server')
+    LoggingScriptServer(rospy.get_name())
+    rospy.spin()

--- a/aaf_logging/scripts/logging_script_server.py
+++ b/aaf_logging/scripts/logging_script_server.py
@@ -45,12 +45,13 @@ class LoggingScriptServer(AbstractTaskServer):
             #    return
             self.running = False
 
-        elif goal.command == "stop" and self.running:
-            rospy.loginfo('now the logging should stop')
-            rospy.loginfo(self.p.pid)
-            os.killpg(os.getpgid(self.p.pid), signal.SIGINT)
-            rospy.loginfo("I'm done")
-            self.running = False
+        elif goal.command == "stop":
+            if self.running:
+                rospy.loginfo('now the logging should stop')
+                rospy.loginfo(self.p.pid)
+                os.killpg(os.getpgid(self.p.pid), signal.SIGINT)
+                rospy.loginfo("I'm done")
+                self.running = False
 
         else:
             rospy.loginfo('goal.command is not valid')

--- a/aaf_logging/scripts/logging_script_server.py
+++ b/aaf_logging/scripts/logging_script_server.py
@@ -34,7 +34,6 @@ class LoggingScriptServer(AbstractTaskServer):
             # check if the goal is preempted
             rate = rospy.Rate(1.0)
             while not rospy.is_shutdown() and not self.server.is_preempt_requested(): # and self.p.poll() is None:
-                rospy.loginfo('Sleeping....')
                 rate.sleep()
 
             rospy.loginfo('Logging is preempted')


### PR DESCRIPTION
This adds an `AbstractTaskServer` action server for running `run_aaf_logger.bash` from the scheduler. I've tested it on the robot and it correctly starts and stops all of the processes (there are no lingering processes). I've also verified that the usual topics are added to mongodb when using this server instead of running logging directly from command line. In the future we might want to run `mongodb_log.py` directly through this server instead of through bash but that would be easy to incorporate. There should be no major drawbacks with having bash as an intermediate.

@marc-hanheide Can you have a quick look at the code?
