### PR TITLE
[aaf_logging] Add logging server for running logging on demand (2nd take)

### DIFF
--- a/aaf_bringup/scripts/aaf_start.sh
+++ b/aaf_bringup/scripts/aaf_start.sh
@@ -19,7 +19,7 @@ tmux new-window -t $SESSION:11 -n 'bell_bot'
 tmux new-window -t $SESSION:12 -n 'walking_group'
 tmux new-window -t $SESSION:13 -n 'scheduler'
 tmux new-window -t $SESSION:14 -n 'control'
-tmux new-window -t $SESSION:15 -n 'logging_script'
+tmux new-window -t $SESSION:15 -n 'logging_server'
 tmux new-window -t $SESSION:16 -n 'pred_map_bags'
 tmux new-window -t $SESSION:17 -n 'screen_broadcast'
 
@@ -76,7 +76,7 @@ tmux send-keys "DISPLAY=:0 roslaunch aaf_bringup aaf_deployment_control.launch"
 
 tmux select-window -t $SESSION:15
 tmux send-keys "ssh werner-left-cortex" C-m
-tmux send-keys "rosrun aaf_logging run_aaf_logger.bash"
+tmux send-keys "rosrun aaf_logging start_stop_logging.py"
 
 tmux select-window -t $SESSION:16
 tmux send-keys "ssh werner-left-cortex" C-m

--- a/aaf_logging/CMakeLists.txt
+++ b/aaf_logging/CMakeLists.txt
@@ -41,6 +41,7 @@ catkin_package()
 
 install(PROGRAMS
   scripts/start_stop_logging.py
+  scripts/run_aaf_logger.bash
   scripts/filter_rosout.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/aaf_logging/launch/logging.launch
+++ b/aaf_logging/launch/logging.launch
@@ -16,8 +16,10 @@
 
     <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="false"/>
 
+    <!--
     <node pkg="aaf_logging" type="start_stop_logging.py" name="logging_server" output="screen" respawn="true"/>
-
+    -->
+    
     <node pkg="aaf_logging" type="store_logs_task.py" name="store_logs" output="screen" respawn="true">
 	<param name="database" value="message_store" />
 	<param name="collections" value="[message_store, nav_stats, monitored_nav_events, people_perception, scheduling_problems, task_events, upper_bodies]" />


### PR DESCRIPTION
This does the same thing as https://github.com/strands-project/aaf_deployment/pull/332, but integrated into the `start_stop_logging.py` action server. I also changed the tmux startup script to launch this on left cortex instead of the logging script and also removed `start_stop_logging.py` from `logging.launch`. Tested it locally but need to test it on the robot again.

@cdondrup Can you have a quick look to see that I haven't missed something?
