### PR TITLE
Adding slack to max_duration of tasks

### DIFF
--- a/aaf_bellbot/scripts/start_bellbot.py
+++ b/aaf_bellbot/scripts/start_bellbot.py
@@ -41,6 +41,7 @@ class StartBellbot(AbstractTaskServer):
             task.end_node_id = task.start_node_id
         if task.max_duration.secs == 0.0:
             task.max_duration = task.end_before - task.start_after
+            task.max_duration.secs -= 120. # Slack for scheduler
         if task.priority == 0:
             task.priority = 2
 

--- a/aaf_walking_group/scripts/start_walking_group.py
+++ b/aaf_walking_group/scripts/start_walking_group.py
@@ -48,6 +48,7 @@ class StartWalkingGroup(AbstractTaskServer):
             task.end_node_id = task.start_node_id
         if task.max_duration.secs == 0.0:
             task.max_duration = task.end_before - task.start_after
+            task.max_duration.secs -= 120. # Slack for scheduler
         if task.priority == 0:
             task.priority = 3
         return task

--- a/info_terminal/info_task/scripts/start_stop_info_terminal.py
+++ b/info_terminal/info_task/scripts/start_stop_info_terminal.py
@@ -30,7 +30,7 @@ class Server(AbstractTaskServer):
             task.start_node_id = self.location
         task.end_node_id = task.start_node_id
         if task.max_duration.secs == 0.0:
-            task.max_duration = task.end_before - task.start_after
+            task.max_duration.secs = 60 # Default execution time: 1min
         if task.priority == 0:
             task.priority = 3
         return task


### PR DESCRIPTION
2 minutes slack for walking group and bellbot.
info_terminal_start and stop are set to a fixed 60 seconds like the logging tasks servers.
