### PR TITLE
Changed starting waypoint of walking group to Kindergarten

### DIFF
--- a/aaf_control_ui/www/tasks.html
+++ b/aaf_control_ui/www/tasks.html
@@ -73,8 +73,8 @@ document.onready = function() {
                                 <div class="panel panel-default">
 									<div class="panel-heading">Nordic Walking Gruppe</div>
 									<div class="panel-body">
-								    	<a type="button" class="btn btn-sm btn-default" onclick="demand_task('walking_group_slow', 'WalkingGruppeStart', 3600);">langsame Gruppe (1h)</a>
-								    	<a type="button" class="btn btn-sm btn-default" onclick="demand_task('walking_group_fast', 'WalkingGruppeStart', 3600);">schnelle Gruppe (1h)</a>
+								    	<a type="button" class="btn btn-sm btn-default" onclick="demand_task('walking_group_slow', 'Kindergarten', 3600);">langsame Gruppe (1h)</a>
+								    	<a type="button" class="btn btn-sm btn-default" onclick="demand_task('walking_group_fast', 'Kindergarten', 3600);">schnelle Gruppe (1h)</a>
 								  	</div>
 								</div>
 

--- a/aaf_walking_group/conf/waypoints.yaml
+++ b/aaf_walking_group/conf/waypoints.yaml
@@ -3,9 +3,9 @@ slow:
     waypoints:
         1:
             resting:
-                "WalkingGruppeStart"
+                "Kindergarten"
             asking:
-                "WalkingGruppeStart"
+                "Kindergarten"
             resting_tag:
                 "Start"
         2: 
@@ -77,9 +77,9 @@ slow:
                 "Ambulanz"
         8:
             resting:
-                "WalkingGruppeStart"
+                "Kindergarten"
             asking:
-                "WalkingGruppeStart"
+                "Kindergarten"
             intermediate:
                 1: "WayPoint88"
             resting_tag:
@@ -89,9 +89,9 @@ fast:
     waypoints:
         1:
             resting:
-                "WalkingGruppeStart"
+                "Kindergarten"
             asking:
-                "WalkingGruppeStart"
+                "Kindergarten"
             resting_tag:
                 "Start"
         2: 
@@ -162,9 +162,9 @@ fast:
                 "Ambulanz"
         8:
             resting:
-                "WalkingGruppeStart"
+                "Kindergarten"
             asking:
-                "WalkingGruppeStart"
+                "Kindergarten"
             intermediate:
                 1: "WayPoint88"
             resting_tag:

--- a/aaf_walking_group/etc/walking_groups.yaml
+++ b/aaf_walking_group/etc/walking_groups.yaml
@@ -1,7 +1,7 @@
 walking_group:
     walking_group_slow:
         group: 'slow'
-        start_location: 'WalkingGruppeStart'
+        start_location: 'Kindergarten'
         parameters: 
             - 'head_machine'
             - 'head_user'
@@ -24,7 +24,7 @@ walking_group:
             - 'aaf_walking_group_pictures'
     walking_group_fast:
         group: 'fast'
-        start_location: 'WalkingGruppeStart'
+        start_location: 'Kindergarten'
         parameters: 
             - 'head_machine'
             - 'head_user'

--- a/aaf_walking_group/www/aaf_map.html
+++ b/aaf_walking_group/www/aaf_map.html
@@ -15,7 +15,7 @@
 	
 	<!-- End -->
 	<button type="button" onclick="var service_button = new ROSLIB.Service({ros : ros, name : '/map_interface_server/button', serviceType : 'aaf_walking_group/Button'}); var request_button = new ROSLIB.ServiceRequest({identifier : '8'});  service_button .callService(request_button, function(result) {console.log('Called service'); }); console.log('Called')"
-            class="button-style ende-button" style="position: absolute; left: 95px; top: 481px; height: 45px; width: 45px;"></button>
+            class="button-style ende-button" style="position: absolute; left: 45px; top: 181px; height: 45px; width: 45px;"></button>
    <!-- Ambulanz -->
 	<button type="button" onclick="var service_button = new ROSLIB.Service({ros : ros, name : '/map_interface_server/button', serviceType : 'aaf_walking_group/Button'}); var request_button = new ROSLIB.ServiceRequest({identifier : '7'});  service_button .callService(request_button, function(result) {console.log('Called service'); }); console.log('Called')"
             class="button-style rast-button-left" style="position: absolute; left: 296px; top: 181px; height: 45px; width: 45px;"></button>


### PR DESCRIPTION
Addressing #347

This changes the starting waypoint of the Walking Group to `Kindergarten`. Only have to make sure that the calendar events are either created with Kindergarten as the starting point or it is left empty and the default is used.

Also updated the button for the control UI to use the new waypoint.

There are a few minor things to update on the robot when reusing the database and topo map from last deployment:

1. Drop the `aaf_walking_group` collection in the `message_store`
1. Insert the updated waypoint list: `rosrun aaf_walking_group insert_yaml.py -i $(rospack find aaf_walking_group)/conf/waypoints.yaml aaf_deployment`
1. Remove tags `Start` and `walking_group_resting_point` from `WalkingGruppeStart`
1. Add the tags `Start` and `walking_group_resting_point` to `Kindergarten`

Voila (as the Spanish say)