### PR TITLE
Fixing error in walking group in case move_base has never received a goal

### DIFF
--- a/aaf_walking_group/scripts/walking_group_recovery_feedback.py
+++ b/aaf_walking_group/scripts/walking_group_recovery_feedback.py
@@ -52,15 +52,16 @@ class RecoveryFeedback(object):
         self.path_stamp = msg.header.stamp.secs
 
     def state_cb(self, msg):
-        if msg.status_list[-1].status == 1:
-            dif = abs(msg.header.stamp.secs - self.path_stamp)
-            if dif > 5.:
-                rospy.logwarn("Robot appears to be stuck.")
-                self.dialogue(True)
+        if msg.status_list:
+            if msg.status_list[-1].status == 1:
+                dif = abs(msg.header.stamp.secs - self.path_stamp)
+                if dif > 5.:
+                    rospy.logwarn("Robot appears to be stuck.")
+                    self.dialogue(True)
+                else:
+                    self.dialogue(False)
             else:
                 self.dialogue(False)
-        else:
-            self.dialogue(False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is an edge case that should never happen but if `move_base` has never received a goal before the walking group is started, the `walking_group_recovery_feedback` would throw constant errors trying to access an empty list. Would still work because at some point `move_base` will have received a goal, but is a little spammy.